### PR TITLE
No `setup-test-cluster` mvn profile

### DIFF
--- a/scripts/PerfTest
+++ b/scripts/PerfTest
@@ -7,7 +7,7 @@ SRCDIR=$(cd "$SCRIPTDIR"/.. && pwd)
 
 (
 	cd "$SRCDIR"
-	mvn -q test-compile -P '!setup-test-cluster'
+	mvn -q test-compile
 	mvn -q exec:java \
 		-Dexec.mainClass="com.rabbitmq.perf.PerfTest" "$@"
 )


### PR DESCRIPTION
Hi @acogoluegnes 

Would you be open to pulling some clean up changes from my fork?

This clean-up commit is removing the extra -P flag from PerfTest `mvn -q test-compile`