### PR TITLE
Support multiple queues to consume from

### DIFF
--- a/html/README.md
+++ b/html/README.md
@@ -293,8 +293,8 @@ The following parameters can be specified for a scenario:
   benchmark. Defaults to `'direct'`
 - exchange-name: exchange name to be used during the
   benchmark. Defaults to whatever `exchangeType` was set to.
-- queue-name: queue name to be used during the benchmark. Defaults to
-  an empty name, letting RabbitMQ provide a random one.
+- queue-names: list of queue names to be used during the benchmark. Defaults to
+  a single queue, letting RabbitMQ provide a random queue name.
 - routing-key: routing key to be used during the benchmark. Defaults to
   an empty routing key.
 - random-routing-key: allows the publisher to send a different routing

--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -220,8 +220,8 @@ public class MulticastParams {
                                      false,
                                      autoDelete,
                                      null).getQueue();
-                generatedQueueNames.add(qName);
             }
+            generatedQueueNames.add(qName);
             channel.queueBind(qName, exchangeName, id);
         }
         channel.abort();

--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -66,10 +66,6 @@ public class MulticastParams {
         this.queueNames = queueNames;
     }
 
-    public void setQueueName(String queueName) {
-        this.queueNames.add(queueName);
-    }
-
     public void setRoutingKey(String routingKey) {
         this.routingKey = routingKey;
     }

--- a/src/main/java/com/rabbitmq/perf/MulticastSet.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastSet.java
@@ -72,9 +72,9 @@ public class MulticastSet {
             consumerThreads[i] = t;
         }
 
-        if (params.shouldConfigureQueue()) {
+        if (params.shouldConfigureQueues()) {
             Connection conn = factory.newConnection();
-            params.configureQueue(conn, id);
+            params.configureQueues(conn, id);
             conn.close();
         }
 

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -16,6 +16,7 @@
 package com.rabbitmq.perf;
 
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
@@ -51,7 +52,7 @@ public class PerfTest {
             testID                   = strArg(cmd, 'd', "test-"+testID);
             String exchangeType      = strArg(cmd, 't', "direct");
             String exchangeName      = strArg(cmd, 'e', exchangeType);
-            String queueName         = strArg(cmd, 'u', "");
+            String queueNames        = strArg(cmd, 'u', "");
             String routingKey        = strArg(cmd, 'k', null);
             boolean randomRoutingKey = cmd.hasOption('K');
             int samplingInterval     = intArg(cmd, 'i', 1);
@@ -111,7 +112,7 @@ public class PerfTest {
             p.setProducerCount(    producerCount);
             p.setProducerMsgCount( producerMsgCount);
             p.setProducerTxSize(   producerTxSize);
-            p.setQueueName(        queueName);
+            p.setQueueNames(        Arrays.asList(queueNames.split(",")));
             p.setRoutingKey(       routingKey);
             p.setRandomRoutingKey( randomRoutingKey);
             p.setProducerRateLimit(producerRateLimit);


### PR DESCRIPTION
This will let us consume from multiple queues at the same time. Allows testing more complicated scenarios.

-------
Edit:


Usage:

You can now provide multiple names in your spec.
Example:
```
[ {
  'name' : 'consume',
  'type' : 'simple',
  'params' : [ {
    'time-limit' : 35,
    'producer-count' : 1,
    'consumer-count' : 2,
    'predeclared' : true,
    'queue-names' : [ 'foo_bar_1', 'foo_bar_2' ]
  } ]
} ]
```
or, for using multiple queues from the cli, provide a comma delimited list of queue names:
```
scripts/runjava com.rabbitmq.perf.PerfTest -u queue1,queue2,queue3
```
Can be used to test multi-node installations where you can try to balance load by creating queues on different nodes etc or if you are using custom exchanges.