### PR TITLE
Narrow down dom element search for chart div

### DIFF
--- a/html/perf.js
+++ b/html/perf.js
@@ -1,10 +1,20 @@
-function render_graphs(results) {
+function render_graphs(results, parentDomElement) {
+  if(typeof parentDomElement === "undefined") {
     $('.chart, .small-chart').map(function() {
         plot($(this), results);
     });
     $('.summary').map(function() {
         summarise($(this), results);
     });
+  }
+  else {
+    parentDomElement.find('.chart, .small-chart').map(function() {
+        plot($(this), results);
+    });
+    parentDomElement.find('.summary').map(function() {
+        summarise($(this), results);
+    });
+  }
 }
 
 function summarise(div, results) {


### PR DESCRIPTION
**This change will not break any existing code**

I created a web app that makes it easy to run and graph these performance tests. https://github.com/johnlonganecker/rabbitmq-performance-app I needed a way to split the graphing into a more modular way.

Currently `render_graphs()` will traverse the entire DOM looking for any element that has a .chart, .small-chart or .summarise class. 

This is probably fine for most use cases, but for my use case I wanted to narrow down this search. the `render_graph()` now takes in an optional parameter (jQuery DOM object) that will be used to narrow down the search to this DOM elements descendants.

