### PR TITLE
Provide publisher options for message properties and size variation.

### DIFF
--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -35,6 +35,7 @@ public class MulticastParams {
     private int channelPrefetch = 0;
     private int consumerPrefetch = 0;
     private int minMsgSize = 0;
+    private int msgSizeVariation = 0;
 
     private int timeLimit = 0;
     private float producerRateLimit = 0;
@@ -55,6 +56,7 @@ public class MulticastParams {
     private boolean autoDelete = false;
 
     private boolean predeclared;
+    private boolean setProperties;
 
     public void setExchangeType(String exchangeType) {
         this.exchangeType = exchangeType;
@@ -132,6 +134,10 @@ public class MulticastParams {
         this.minMsgSize = minMsgSize;
     }
 
+    public void setMsgSizeVariation(int msgSizeVariation) {
+        this.msgSizeVariation = msgSizeVariation;
+    }
+
     public void setTimeLimit(int timeLimit) {
         this.timeLimit = timeLimit;
     }
@@ -159,6 +165,10 @@ public class MulticastParams {
 
     public void setPredeclared(boolean predeclared) {
         this.predeclared = predeclared;
+    }
+
+    public void setSetProperties(boolean setProperties) {
+        this.setProperties = setProperties;
     }
 
     public int getConsumerCount() {
@@ -189,6 +199,10 @@ public class MulticastParams {
         return minMsgSize;
     }
 
+    public int getMsgSizeVariation() {
+        return msgSizeVariation;
+    }
+
     public String getRoutingKey() {
         return routingKey;
     }
@@ -207,8 +221,8 @@ public class MulticastParams {
         final Producer producer = new Producer(channel, exchangeName, id,
                                                randomRoutingKey, flags, producerTxSize,
                                                producerRateLimit, producerMsgCount,
-                                               minMsgSize, timeLimit,
-                                               confirm, stats);
+                                               minMsgSize, msgSizeVariation, timeLimit,
+                                               confirm, stats, setProperties);
         channel.addReturnListener(producer);
         channel.addConfirmListener(producer);
         return producer;

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -66,6 +66,10 @@ public class PerfTest {
             int channelPrefetch      = intArg(cmd, 'Q', 0);
             int consumerPrefetch     = intArg(cmd, 'q', 0);
             int minMsgSize           = intArg(cmd, 's', 0);
+            int msgSizeVariation     = intArg(cmd, 'v', 0);
+            if (msgSizeVariation >= minMsgSize) {
+                msgSizeVariation = 0;
+            }
             int timeLimit            = intArg(cmd, 'z', 0);
             int producerMsgCount     = intArg(cmd, 'C', 0);
             int consumerMsgCount     = intArg(cmd, 'D', 0);
@@ -73,6 +77,7 @@ public class PerfTest {
             int frameMax             = intArg(cmd, 'M', 0);
             int heartbeat            = intArg(cmd, 'b', 0);
             boolean predeclared      = cmd.hasOption('p');
+            boolean setProperties    = cmd.hasOption('P');
 
             String uri               = strArg(cmd, 'h', "amqp://localhost");
 
@@ -105,6 +110,7 @@ public class PerfTest {
             p.setFlags(                 flags);
             p.setMultiAckEvery(         multiAckEvery);
             p.setMinMsgSize(            minMsgSize);
+            p.setMsgSizeVariation(      msgSizeVariation);
             p.setPredeclared(           predeclared);
             p.setConsumerPrefetch(      consumerPrefetch);
             p.setChannelPrefetch(       channelPrefetch);
@@ -117,6 +123,7 @@ public class PerfTest {
             p.setRandomRoutingKey(      randomRoutingKey);
             p.setProducerRateLimit(     producerRateLimit);
             p.setTimeLimit(             timeLimit);
+            p.setSetProperties(         setProperties);
 
             MulticastSet set = new MulticastSet(stats, factory, p, testID);
             set.run(true);
@@ -163,6 +170,7 @@ public class PerfTest {
         options.addOption(new Option("q", "qos",                    true, "consumer prefetch count"));
         options.addOption(new Option("Q", "globalQos",              true, "channel prefetch count"));
         options.addOption(new Option("s", "size",                   true, "message size in bytes"));
+        options.addOption(new Option("v", "variation",              true, "message size variation in bytes"));
         options.addOption(new Option("z", "time",                   true, "run duration in seconds (unlimited by default)"));
         options.addOption(new Option("C", "pmessages",              true, "producer message count"));
         options.addOption(new Option("D", "cmessages",              true, "consumer message count"));
@@ -172,6 +180,7 @@ public class PerfTest {
         options.addOption(new Option("M", "framemax",               true, "frame max"));
         options.addOption(new Option("b", "heartbeat",              true, "heartbeat interval"));
         options.addOption(new Option("p", "predeclared",            false,"allow use of predeclared objects"));
+        options.addOption(new Option("P", "properties",             false,"set message properties"));
         return options;
     }
 


### PR DESCRIPTION
I've added two options that allow tests to more closely mimic my
actual use cases.  Both ultimately affect server I/O
(especially when testing lazy queues) and garbage collection
patterns.  Neither is very invasive in the code.

The remainder of this is taken from the commit message:

To create tests that more closely mimic actual use cases, the -v
(variation) option specifies the variation in size from the -s
(size) value specified.  The variations are chosen randomly from a
uniform distribution.  If the specified variation is larger than or
equal to the specified size, the variation is silently set to 0.

To more closely mimic actual use cases, the -P (set message properties)
option sets the value of some message properties.  Specifically,

  * app_id is the name of the Publisher class
  * content type is application/octet-stream
  * delivery_mode is 1 (default) or 2 (if persistent flag is set)
  * message_id is the test sequence number of the message
  * priority is 0
  * timestamp is the instant at which the message was constructed

Although these properties may be a small number of bytes compared to
large message payloads, they add to the number of items allocated on
the erlang heap and thus affect garbage collection.