### PR TITLE
Add a flag to print median and percentiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
 
     <rabbitmq.version>4.1.1</rabbitmq.version>
     <commons-cli.version>1.1</commons-cli.version>
+    <metrics.version>3.2.3</metrics.version>
     <logback.version>1.1.8</logback.version>
     <jetty.version>8.1.19.v20160209</jetty.version>
     <junit.version>4.12</junit.version>
@@ -76,6 +77,11 @@
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
       <version>${commons-cli.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>${metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/scripts/PerfTest
+++ b/scripts/PerfTest
@@ -9,5 +9,5 @@ SRCDIR=$(cd "$SCRIPTDIR"/.. && pwd)
 	cd "$SRCDIR"
 	mvn -q compile
 	mvn -q exec:java \
-		-Dexec.mainClass="com.rabbitmq.perf.PerfTest" -Dexec.args="$@"
+		-Dexec.mainClass="com.rabbitmq.perf.PerfTest" -Dexec.args="$*"
 )

--- a/src/main/java/com/rabbitmq/perf/Stats.java
+++ b/src/main/java/com/rabbitmq/perf/Stats.java
@@ -15,6 +15,9 @@
 
 package com.rabbitmq.perf;
 
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+
 public abstract class Stats {
     protected final long    interval;
 
@@ -40,6 +43,8 @@ public abstract class Stats {
     protected long    elapsedInterval;
     protected long    elapsedTotal;
 
+    protected Histogram latency = new MetricRegistry().histogram("latency");;
+
     public Stats(long interval) {
         this.interval = interval;
         startTime = System.currentTimeMillis();
@@ -59,6 +64,7 @@ public abstract class Stats {
         maxLatency                = Long.MIN_VALUE;
         latencyCountInterval      = 0;
         cumulativeLatencyInterval = 0L;
+        latency                   = new MetricRegistry().histogram("latency");
     }
 
     private void report() {
@@ -99,6 +105,7 @@ public abstract class Stats {
         recvCountInterval++;
         recvCountTotal++;
         if (latency > 0) {
+            this.latency.update(latency);
             minLatency = Math.min(minLatency, latency);
             maxLatency = Math.max(maxLatency, latency);
             cumulativeLatencyInterval += latency;


### PR DESCRIPTION
The -S flag can be used to print median and percentiles.
It's not default to avoid a breaking change. It should be
made the default in 2.0.
The metrics are based on Dropwizard Metrics.

Fixes #27