### PR TITLE
Allow passing the default exchange as an argument

### DIFF
--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -296,7 +296,7 @@ public class MulticastParams {
     }
 
     private static boolean exchangeExists(Connection connection, final String exchangeName) throws IOException {
-        if (exchangeName == "") {
+        if (exchangeName.equals("")) {
             // NB: default exchange always exists
             return true;
         } else {

--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -296,11 +296,16 @@ public class MulticastParams {
     }
 
     private static boolean exchangeExists(Connection connection, final String exchangeName) throws IOException {
-        return exists(connection, new Checker() {
-            public void check(Channel ch) throws IOException {
-                ch.exchangeDeclarePassive(exchangeName);
-            }
-        });
+        if (exchangeName == "") {
+            // NB: default exchange always exists
+            return true;
+        } else {
+            return exists(connection, new Checker() {
+                public void check(Channel ch) throws IOException {
+                    ch.exchangeDeclarePassive(exchangeName);
+                }
+            });
+        }
     }
 
     private static boolean queueExists(Connection connection, final String queueName) throws IOException {

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -59,7 +59,7 @@ public class PerfTest {
                 getInstance().getTime());
             testID                   = strArg(cmd, 'd', "test-"+testID);
             String exchangeType      = strArg(cmd, 't', "direct");
-            String exchangeName      = strArg(cmd, 'e', exchangeType);
+            String exchangeName      = getExchangeName(cmd, exchangeType);
             String queueNames        = strArg(cmd, 'u', "");
             String routingKey        = strArg(cmd, 'k', null);
             boolean randomRoutingKey = cmd.hasOption('K');
@@ -223,7 +223,12 @@ public class PerfTest {
         options.addOption(new Option("h", "uri",                    true, "connection URI"));
         options.addOption(new Option("H", "uris",                   true, "connection URIs (separated by commas)"));
         options.addOption(new Option("t", "type",                   true, "exchange type"));
-        options.addOption(new Option("e", "exchange",               true, "exchange name"));
+
+        final Option exchangeOpt = new Option("e", "exchange name");
+        exchangeOpt.setLongOpt("exchange");
+        exchangeOpt.setOptionalArg(true);
+        options.addOption(exchangeOpt);
+
         options.addOption(new Option("u", "queue",                  true, "queue name"));
         options.addOption(new Option("k", "routingKey",             true, "routing key"));
         options.addOption(new Option("K", "randomRoutingKey",       false,"use random routing key per message"));
@@ -253,12 +258,12 @@ public class PerfTest {
         options.addOption(new Option("p", "predeclared",            false,"allow use of predeclared objects"));
         options.addOption(new Option("B", "body",                   true, "comma-separated list of files to use in message bodies"));
         options.addOption(new Option("T", "bodyContenType",         true, "body content-type"));
-        options.addOption(new Option("l", "legacyMetrics",           false, "display legacy metrics (min/avg/max latency)"));
+        options.addOption(new Option("l", "legacyMetrics",          false, "display legacy metrics (min/avg/max latency)"));
         options.addOption(new Option("o", "outputFile",             true, "output file for timing results"));
-        options.addOption(new Option("ad", "autoDelete", true, "should the queue be auto-deleted, default is true"));
-        options.addOption(new Option("qa", "queueArgs", true, "queue arguments as key/pair values, separated by commas"));
-        options.addOption(new Option("L", "consumerLatency", true, "consumer latency in microseconds"));
-        options.addOption(new Option("useDefaultSslContext", "useDefaultSslContext",       false,"use JVM default SSL context"));
+        options.addOption(new Option("ad", "autoDelete",            true, "should the queue be auto-deleted, default is true"));
+        options.addOption(new Option("qa", "queueArgs",             true, "queue arguments as key/pair values, separated by commas"));
+        options.addOption(new Option("L", "consumerLatency",        true, "consumer latency in microseconds"));
+        options.addOption(new Option("useDefaultSslContext", "useDefaultSslContext", false,"use JVM default SSL context"));
         return options;
     }
 
@@ -304,6 +309,20 @@ public class PerfTest {
             }
         }
         return queueArguments;
+    }
+
+    private static String getExchangeName(CommandLine cmd, String def) {
+        String exchangeName = null;
+        if (cmd.hasOption('e')) {
+            exchangeName = cmd.getOptionValue('e');
+            // TODO: what would be a good constant to use for the default exchange?
+            if (exchangeName == null || exchangeName.equalsIgnoreCase("AMQP-default")) {
+                exchangeName = "";
+            }
+        } else {
+            exchangeName = def;
+        }
+        return exchangeName;
     }
 
     private static class PrintlnStats extends Stats {

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -315,8 +315,7 @@ public class PerfTest {
         String exchangeName = null;
         if (cmd.hasOption('e')) {
             exchangeName = cmd.getOptionValue('e');
-            // TODO: what would be a good constant to use for the default exchange?
-            if (exchangeName == null || exchangeName.equalsIgnoreCase("AMQP-default")) {
+            if (exchangeName == null || exchangeName.equals("amq.default")) {
                 exchangeName = "";
             }
         } else {


### PR DESCRIPTION
Part of the fix to #43

Currently, there is no way to specify using the default exchange as the `-e` / `--exchange` argument requires a non-null, non-empty string value. You can not pass the empty string to specify using the default exchange.

Also, is `AMQP-default` a good representation of the default exchange's name?