### PR TITLE
Support for testing sharded queues

### DIFF
--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -49,6 +49,7 @@ public class MulticastParams {
     private List<String> queueNames = new ArrayList<String>();
     private String routingKey = null;
     private boolean randomRoutingKey = false;
+    private boolean skipBindingQueues = false;
 
     private List<?> flags = new ArrayList<Object>();
 
@@ -87,6 +88,10 @@ public class MulticastParams {
 
     public void setRandomRoutingKey(boolean randomRoutingKey) {
         this.randomRoutingKey = randomRoutingKey;
+    }
+    
+    public void setSkipBindingQueues(boolean skipBindingQueues) {
+    	this.skipBindingQueues = skipBindingQueues;
     }
 
     public void setProducerRateLimit(float producerRateLimit) {
@@ -225,6 +230,10 @@ public class MulticastParams {
     public boolean getRandomRoutingKey() {
         return randomRoutingKey;
     }
+    
+    public boolean getSkipBindingQueues() {
+    	return skipBindingQueues;
+    }
 
     public void setBodyFiles(List<String> bodyFiles) {
         if (bodyFiles == null) {
@@ -303,7 +312,7 @@ public class MulticastParams {
             generatedQueueNames.add(qName);
             // skipping binding to default exchange,
             // as it's not possible to explicitly bind to it.
-            if (!predeclared && !"".equals(exchangeName) && !"amq.default".equals(exchangeName)) {
+            if (!"".equals(exchangeName) && !"amq.default".equals(exchangeName) && !skipBindingQueues) {
                 channel.queueBind(qName, exchangeName, id);
             }
         }

--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -299,13 +299,13 @@ public class MulticastParams {
                                      false,
                                      autoDelete,
                                      queueArguments).getQueue();
-                // skipping binding to default exchange,
-                // as it's not possible to explicitly bind to it.
-                if (!"".equals(exchangeName) && !"amq.default".equals(exchangeName)) {
-                    channel.queueBind(qName, exchangeName, id);
-                }
             }
             generatedQueueNames.add(qName);
+            // skipping binding to default exchange,
+            // as it's not possible to explicitly bind to it.
+            if (!predeclared && !"".equals(exchangeName) && !"amq.default".equals(exchangeName)) {
+                channel.queueBind(qName, exchangeName, id);
+            }
         }
         channel.abort();
 

--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -42,6 +42,7 @@ public class MulticastParams {
     private float consumerRateLimit = 0;
     private int producerMsgCount = 0;
     private int consumerMsgCount = 0;
+	private boolean consumerSlowStart = false;
 
     private String exchangeName = "direct";
     private String exchangeType = "direct";
@@ -111,6 +112,10 @@ public class MulticastParams {
     public void setConsumerChannelCount(int consumerChannelCount) {
         this.consumerChannelCount = consumerChannelCount;
     }
+    
+	public void setConsumerSlowStart(boolean slowStart) {
+		this.consumerSlowStart = slowStart;
+	}
 
     public void setProducerTxSize(int producerTxSize) {
         this.producerTxSize = producerTxSize;
@@ -187,6 +192,10 @@ public class MulticastParams {
 
     public int getConsumerChannelCount() {
         return consumerChannelCount;
+    }
+    
+    public boolean getConsumerSlowStart() {
+    	return consumerSlowStart;
     }
 
     public int getConsumerThreadCount() {
@@ -290,13 +299,13 @@ public class MulticastParams {
                                      false,
                                      autoDelete,
                                      queueArguments).getQueue();
+                // skipping binding to default exchange,
+                // as it's not possible to explicitly bind to it.
+                if (!"".equals(exchangeName) && !"amq.default".equals(exchangeName)) {
+                    channel.queueBind(qName, exchangeName, id);
+                }
             }
             generatedQueueNames.add(qName);
-            // skipping binding to default exchange,
-            // as it's not possible to explicitly bind to it.
-            if (!"".equals(exchangeName) && !"amq.default".equals(exchangeName)) {
-                channel.queueBind(qName, exchangeName, id);
-            }
         }
         channel.abort();
 

--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -42,7 +42,7 @@ public class MulticastParams {
     private float consumerRateLimit = 0;
     private int producerMsgCount = 0;
     private int consumerMsgCount = 0;
-	private boolean consumerSlowStart = false;
+    private boolean consumerSlowStart = false;
 
     private String exchangeName = "direct";
     private String exchangeType = "direct";
@@ -113,9 +113,9 @@ public class MulticastParams {
         this.consumerChannelCount = consumerChannelCount;
     }
     
-	public void setConsumerSlowStart(boolean slowStart) {
-		this.consumerSlowStart = slowStart;
-	}
+    public void setConsumerSlowStart(boolean slowStart) {
+        this.consumerSlowStart = slowStart;
+    }
 
     public void setProducerTxSize(int producerTxSize) {
         this.producerTxSize = producerTxSize;
@@ -195,7 +195,7 @@ public class MulticastParams {
     }
     
     public boolean getConsumerSlowStart() {
-    	return consumerSlowStart;
+        return consumerSlowStart;
     }
 
     public int getConsumerThreadCount() {

--- a/src/main/java/com/rabbitmq/perf/MulticastSet.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastSet.java
@@ -116,6 +116,10 @@ public class MulticastSet {
 
         for (Thread consumerThread : consumerThreads) {
             consumerThread.start();
+            if(params.getConsumerSlowStart()) {
+            	System.out.println("slowStart: wait 1sec");
+            	Thread.sleep(1000);
+            }
         }
 
         for (Thread producerThread : producerThreads) {

--- a/src/main/java/com/rabbitmq/perf/MulticastSet.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastSet.java
@@ -117,7 +117,7 @@ public class MulticastSet {
         for (Thread consumerThread : consumerThreads) {
             consumerThread.start();
             if(params.getConsumerSlowStart()) {
-            	System.out.println("slowStart: wait 1sec");
+            	System.out.println("Delaying start by 1 second because -S/--slow-start was requested");
             	Thread.sleep(1000);
             }
         }

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -78,6 +78,7 @@ public class PerfTest {
             int channelPrefetch      = intArg(cmd, 'Q', 0);
             int consumerPrefetch     = intArg(cmd, 'q', 0);
             int minMsgSize           = intArg(cmd, 's', 0);
+            boolean slowStart        = cmd.hasOption('S');
             int timeLimit            = intArg(cmd, 'z', 0);
             int producerMsgCount     = intArg(cmd, 'C', 0);
             int consumerMsgCount     = intArg(cmd, 'D', 0);
@@ -154,6 +155,7 @@ public class PerfTest {
             p.setConsumerMsgCount(      consumerMsgCount);
             p.setConsumerRateLimit(     consumerRateLimit);
             p.setConsumerTxSize(        consumerTxSize);
+            p.setConsumerSlowStart(slowStart);
             p.setExchangeName(          exchangeName);
             p.setExchangeType(          exchangeType);
             p.setFlags(                 flags);
@@ -238,6 +240,7 @@ public class PerfTest {
         options.addOption(new Option("R", "consumer-rate",          true, "consumer rate limit"));
         options.addOption(new Option("x", "producers",              true, "producer count"));
         options.addOption(new Option("y", "consumers",              true, "consumer count"));
+        options.addOption(new Option("S", "slow-start",             false,"start consumers slowly"));
         options.addOption(new Option("X", "producer-channel-count", true, "channels per producer"));
         options.addOption(new Option("Y", "consumer-channel-count", true, "channels per consumer"));
         options.addOption(new Option("m", "ptxsize",                true, "producer tx size"));

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -155,7 +155,7 @@ public class PerfTest {
             p.setConsumerMsgCount(      consumerMsgCount);
             p.setConsumerRateLimit(     consumerRateLimit);
             p.setConsumerTxSize(        consumerTxSize);
-            p.setConsumerSlowStart(slowStart);
+            p.setConsumerSlowStart(     slowStart);
             p.setExchangeName(          exchangeName);
             p.setExchangeType(          exchangeType);
             p.setFlags(                 flags);
@@ -240,7 +240,7 @@ public class PerfTest {
         options.addOption(new Option("R", "consumer-rate",          true, "consumer rate limit"));
         options.addOption(new Option("x", "producers",              true, "producer count"));
         options.addOption(new Option("y", "consumers",              true, "consumer count"));
-        options.addOption(new Option("S", "slow-start",             false,"start consumers slowly"));
+        options.addOption(new Option("S", "slow-start",             false,"start consumers slowly (1 sec delay between each)"));
         options.addOption(new Option("X", "producer-channel-count", true, "channels per producer"));
         options.addOption(new Option("Y", "consumer-channel-count", true, "channels per consumer"));
         options.addOption(new Option("m", "ptxsize",                true, "producer tx size"));

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -63,6 +63,7 @@ public class PerfTest {
             String queueNames        = strArg(cmd, 'u', null);
             String routingKey        = strArg(cmd, 'k', null);
             boolean randomRoutingKey = cmd.hasOption('K');
+            boolean skipBindingQueues= cmd.hasOption("sb");
             int samplingInterval     = intArg(cmd, 'i', 1);
             float producerRateLimit  = floatArg(cmd, 'r', 0.0f);
             float consumerRateLimit  = floatArg(cmd, 'R', 0.0f);
@@ -170,6 +171,7 @@ public class PerfTest {
             p.setProducerTxSize(        producerTxSize);
             p.setQueueNames(            queueNames == null ? null : asList(queueNames.split(",")));
             p.setRoutingKey(            routingKey);
+            p.setSkipBindingQueues(     skipBindingQueues);
             p.setRandomRoutingKey(      randomRoutingKey);
             p.setProducerRateLimit(     producerRateLimit);
             p.setTimeLimit(             timeLimit);
@@ -235,6 +237,7 @@ public class PerfTest {
         options.addOption(new Option("u", "queue",                  true, "queue name"));
         options.addOption(new Option("k", "routing-key",            true, "routing key"));
         options.addOption(new Option("K", "random-routing-key",     false,"use random routing key per message"));
+        options.addOption(new Option("sb", "skip-binding-queues",   false,"don't bind queues to the exchange"));
         options.addOption(new Option("i", "interval",               true, "sampling interval in seconds"));
         options.addOption(new Option("r", "rate",                   true, "producer rate limit"));
         options.addOption(new Option("R", "consumer-rate",          true, "consumer rate limit"));


### PR DESCRIPTION
This PR adds support for testing sharded queues.

A new option -S/--slow-start inserts a 1 second delay between starting each consumer.

If a queue is predeclared (-p), then it will not be bound to the exchange.