### PR TITLE
Add "--use-millis" option

### DIFF
--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -62,6 +62,7 @@ public class MulticastParams {
     private String bodyContentType = null;
 
     private boolean predeclared;
+    private boolean useMillis;
 
     private Map<String, Object> queueArguments;
 
@@ -163,6 +164,10 @@ public class MulticastParams {
         this.timeLimit = timeLimit;
     }
 
+    public void setUseMillis(boolean useMillis) {
+        this.useMillis = useMillis;
+    }
+
     public void setProducerMsgCount(int producerMsgCount) {
         this.producerMsgCount = producerMsgCount;
     }
@@ -260,20 +265,20 @@ public class MulticastParams {
             channel.exchangeDeclare(exchangeName, exchangeType);
         }
         MessageBodySource messageBodySource = null;
-        boolean timestampInHeader;
+        TimestampProvider tsp;
         if (bodyFiles.size() > 0) {
+            tsp = new TimestampProvider(useMillis, true);
             messageBodySource = new LocalFilesMessageBodySource(bodyFiles, bodyContentType);
-            timestampInHeader = true;
         } else {
-            messageBodySource = new TimeSequenceMessageBodySource(minMsgSize);
-            timestampInHeader = false;
+            tsp = new TimestampProvider(useMillis, false);
+            messageBodySource = new TimeSequenceMessageBodySource(tsp, minMsgSize);
         }
         final Producer producer = new Producer(channel, exchangeName, id,
                                                randomRoutingKey, flags, producerTxSize,
                                                producerRateLimit, producerMsgCount,
                                                timeLimit,
                                                confirm, confirmTimeout, messageBodySource,
-                                               timestampInHeader, stats);
+                                               tsp, stats);
         channel.addReturnListener(producer);
         channel.addConfirmListener(producer);
         return producer;
@@ -292,11 +297,11 @@ public class MulticastParams {
         } else {
             timestampInHeader = false;
         }
-
+        TimestampProvider tsp = new TimestampProvider(useMillis, timestampInHeader);
         return new Consumer(channel, id, generatedQueueNames,
                                          consumerTxSize, autoAck, multiAckEvery,
                                          stats, consumerRateLimit, consumerMsgCount, timeLimit,
-                                         consumerLatencyInMicroseconds, timestampInHeader);
+                                         consumerLatencyInMicroseconds, tsp);
     }
 
     public boolean shouldConfigureQueues() {

--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -264,7 +264,7 @@ public class MulticastParams {
         if (!predeclared || !exchangeExists(connection, exchangeName)) {
             channel.exchangeDeclare(exchangeName, exchangeType);
         }
-        MessageBodySource messageBodySource = null;
+        MessageBodySource messageBodySource;
         TimestampProvider tsp;
         if (bodyFiles.size() > 0) {
             tsp = new TimestampProvider(useMillis, true);

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -107,13 +107,7 @@ public class PerfTest {
                     file.delete();
                 }
                 output = new PrintWriter(new BufferedWriter(new FileWriter(file)), true);
-                Runtime.getRuntime().addShutdownHook(new Thread() {
-
-                    @Override
-                    public void run() {
-                        output.close();
-                    }
-                });
+                Runtime.getRuntime().addShutdownHook(new Thread(() -> output.close()));
             } else {
                 output = null;
             }

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -112,7 +112,7 @@ public class PerfTest {
                 output = null;
             }
 
-            List<String> uris = null;
+            List<String> uris;
             if(urisParameter != null) {
                 String [] urisArray = urisParameter.split(",");
                 for(int i = 0; i< urisArray.length; i++) {
@@ -266,7 +266,8 @@ public class PerfTest {
         options.addOption(new Option("l", "legacy-metrics",         false,"display legacy metrics (min/avg/max latency)"));
         options.addOption(new Option("o", "output-file",            true, "output file for timing results"));
         options.addOption(new Option("ad", "auto-delete",           true, "should the queue be auto-deleted, default is true"));
-        options.addOption(new Option("ms", "use-millis",            false,"should latency be collected in milliseconds, default is false"));
+        options.addOption(new Option("ms", "use-millis",            false,"should latency be collected in milliseconds, default is false. "
+                                                                                                    + "Set to true if producers are consumers run on different machines."));
         options.addOption(new Option("qa", "queue-args",            true, "queue arguments as key/pair values, separated by commas"));
         options.addOption(new Option("L", "consumer-latency",       true, "consumer latency in microseconds"));
         options.addOption(new Option("udsc", "use-default-ssl-context", false,"use JVM default SSL context"));

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -92,6 +92,7 @@ public class PerfTest {
             boolean predeclared      = cmd.hasOption('p');
             boolean legacyMetrics    = cmd.hasOption('l');
             boolean autoDelete       = boolArg(cmd, "ad", true);
+            boolean useMillis        = cmd.hasOption("ms");
             String queueArgs         = strArg(cmd, "qa", null);
             int consumerLatencyInMicroseconds = intArg(cmd, 'L', 0);
 
@@ -133,9 +134,8 @@ public class PerfTest {
                 1000L * samplingInterval,
                 producerCount > 0,
                 consumerCount > 0,
-                (flags.contains("mandatory") ||
-                    flags.contains("immediate")),
-                confirm != -1, legacyMetrics, output);
+                (flags.contains("mandatory") || flags.contains("immediate")),
+                confirm != -1, legacyMetrics, useMillis, output);
 
             SSLContext sslContext = getSslContextIfNecessary(cmd, System.getProperties());
 
@@ -177,6 +177,7 @@ public class PerfTest {
             p.setRandomRoutingKey(      randomRoutingKey);
             p.setProducerRateLimit(     producerRateLimit);
             p.setTimeLimit(             timeLimit);
+            p.setUseMillis(             useMillis);
             p.setBodyFiles(             bodyFiles == null ? null : asList(bodyFiles.split(",")));
             p.setBodyContentType(       bodyContentType);
             p.setQueueArguments(queueArguments(queueArgs));
@@ -187,7 +188,7 @@ public class PerfTest {
 
             stats.printFinal();
         }
-        catch( ParseException exp ) {
+        catch (ParseException exp) {
             System.err.println("Parsing failed. Reason: " + exp.getMessage());
             usage(options);
         } catch (Exception e) {
@@ -268,9 +269,10 @@ public class PerfTest {
         options.addOption(new Option("p", "predeclared",            false,"allow use of predeclared objects"));
         options.addOption(new Option("B", "body",                   true, "comma-separated list of files to use in message bodies"));
         options.addOption(new Option("T", "body-content-type",      true, "body content-type"));
-        options.addOption(new Option("l", "legacy-metrics",         false, "display legacy metrics (min/avg/max latency)"));
+        options.addOption(new Option("l", "legacy-metrics",         false,"display legacy metrics (min/avg/max latency)"));
         options.addOption(new Option("o", "output-file",            true, "output file for timing results"));
         options.addOption(new Option("ad", "auto-delete",           true, "should the queue be auto-deleted, default is true"));
+        options.addOption(new Option("ms", "use-millis",            false,"should latency be collected in milliseconds, default is false"));
         options.addOption(new Option("qa", "queue-args",            true, "queue arguments as key/pair values, separated by commas"));
         options.addOption(new Option("L", "consumer-latency",       true, "consumer latency in microseconds"));
         options.addOption(new Option("udsc", "use-default-ssl-context", false,"use JVM default SSL context"));
@@ -344,6 +346,7 @@ public class PerfTest {
         private final boolean returnStatsEnabled;
         private final boolean confirmStatsEnabled;
         private final boolean legacyMetrics;
+        private final boolean useMillis;
 
         private final String testID;
         private final PrintWriter out;
@@ -351,7 +354,7 @@ public class PerfTest {
         public PrintlnStats(String testID, long interval,
             boolean sendStatsEnabled, boolean recvStatsEnabled,
             boolean returnStatsEnabled, boolean confirmStatsEnabled,
-            boolean legacyMetrics,
+            boolean legacyMetrics, boolean useMillis,
             PrintWriter out) {
             super(interval);
             this.sendStatsEnabled = sendStatsEnabled;
@@ -360,13 +363,13 @@ public class PerfTest {
             this.confirmStatsEnabled = confirmStatsEnabled;
             this.testID = testID;
             this.legacyMetrics = legacyMetrics;
+            this.useMillis = useMillis;
             this.out = out;
             if (out != null) {
                 out.println("id,time (s),sent (msg/s),returned (msg/s),confirmed (msg/s), nacked (msg/s), received (msg/s),"
                     + "min latency (microseconds),median latency (microseconds),75th p. latency (microseconds),95th p. latency (microseconds),"
                     + "99th p. latency (microseconds)");
             }
-
         }
 
         @Override
@@ -391,11 +394,10 @@ public class PerfTest {
             } else {
                 output += (latencyCountInterval > 0 ?
                     ", min/median/75th/95th/99th latency: "
-                        + latency.getSnapshot().getMin()/1000L + "/"
-                        + (long) latency.getSnapshot().getMedian()/1000L + "/"
-                        + (long) latency.getSnapshot().get75thPercentile()/1000L + "/"
-                        + (long) latency.getSnapshot().get95thPercentile()/1000L + "/"
-                        + (long) latency.getSnapshot().get99thPercentile()/1000L +  " microseconds" :
+                        + div(latency.getSnapshot().getMin()) + "/"
+                        + div(latency.getSnapshot().getMedian()) + "/"
+                        + div(latency.getSnapshot().get75thPercentile()) + "/"
+                        + div(latency.getSnapshot().get95thPercentile()) + units() :
                     "");
             }
 
@@ -408,23 +410,40 @@ public class PerfTest {
                     rate(nackCountInterval, elapsedInterval, sendStatsEnabled && confirmStatsEnabled)+ "," +
                     rate(recvCountInterval, elapsedInterval, recvStatsEnabled) + "," +
                     (latencyCountInterval > 0 ?
-                        latency.getSnapshot().getMin()/1000L + "," +
-                        (long) latency.getSnapshot().getMedian()/1000L + "," +
-                        (long) latency.getSnapshot().get75thPercentile()/1000L + "," +
-                        (long) latency.getSnapshot().get95thPercentile()/1000L + "," +
-                        (long) latency.getSnapshot().get99thPercentile()/1000L
+                        div(latency.getSnapshot().getMin()) + "," +
+                        div(latency.getSnapshot().getMedian()) + "," +
+                        div(latency.getSnapshot().get75thPercentile()) + "," +
+                        div(latency.getSnapshot().get95thPercentile()) + "," +
+                        div(latency.getSnapshot().get99thPercentile())
                         : ",,,,")
                 );
             }
 
         }
 
+        private String units() {
+            if (useMillis) {
+                return " milliseconds";
+            } else {
+                return " microseconds";
+            }
+        }
+
+        private long div(double p) {
+            if (useMillis) {
+                return (long)p;
+            } else {
+                return (long)(p / 1000L);
+            }
+        }
+
         private String getRate(String descr, long count, boolean display,
             long elapsed) {
-            if (display)
+            if (display) {
                 return ", " + descr + ": " + formatRate(1000.0 * count / elapsed) + " msg/s";
-            else
+            } else {
                 return "";
+            }
         }
 
         public void printFinal() {

--- a/src/main/java/com/rabbitmq/perf/TimeSequenceMessageBodySource.java
+++ b/src/main/java/com/rabbitmq/perf/TimeSequenceMessageBodySource.java
@@ -24,9 +24,11 @@ import java.io.IOException;
  */
 public class TimeSequenceMessageBodySource implements MessageBodySource {
 
+    private final TimestampProvider tsp;
     private final byte[] message;
 
-    public TimeSequenceMessageBodySource(int minMsgSize) {
+    public TimeSequenceMessageBodySource(TimestampProvider tsp, int minMsgSize) {
+        this.tsp = tsp;
         this.message = new byte[minMsgSize];
     }
 
@@ -34,9 +36,9 @@ public class TimeSequenceMessageBodySource implements MessageBodySource {
     public MessageBodyAndContentType create(int sequenceNumber) throws IOException {
         ByteArrayOutputStream acc = new ByteArrayOutputStream();
         DataOutputStream d = new DataOutputStream(acc);
-        long nano = System.nanoTime();
+        long time = tsp.getCurrentTime();
         d.writeInt(sequenceNumber);
-        d.writeLong(nano);
+        d.writeLong(time);
         d.flush();
         acc.flush();
         byte[] m = acc.toByteArray();

--- a/src/main/java/com/rabbitmq/perf/TimestampProvider.java
+++ b/src/main/java/com/rabbitmq/perf/TimestampProvider.java
@@ -1,0 +1,42 @@
+// Copyright (c) 2007-Present Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.perf;
+
+public class TimestampProvider {
+    private final boolean useMillis;
+    private final boolean isTimestampInHeader;
+
+    public TimestampProvider(boolean useMillis, boolean isTimestampInHeader) {
+        this.useMillis = useMillis;
+        this.isTimestampInHeader = isTimestampInHeader;
+    }
+
+    public boolean isTimestampInHeader() {
+        return this.isTimestampInHeader;
+    }
+
+    public long getCurrentTime() {
+        if (useMillis) {
+            return System.currentTimeMillis();
+        } else {
+            return System.nanoTime();
+        }
+    }
+
+    public long getDifference(long ts1, long ts2) {
+        return Math.abs(ts1 - ts2);
+    }
+}


### PR DESCRIPTION
This allows producers and consumers to run on different machines while still providing latency output. `System.nanoTime()` may not provide timestamps with the same starting point or even with the same resolution between two different Java VMs on different machines.

Obviously, the clocks between different machines should be synchronized via NTP.

To test, run with these arguments on one VM to produce messages - note that without using the same routing key you won't get latency numbers, either -

```
--producers 1 --consumers 0 --predeclared --routing-key MY-ROUTING-KEY --queue MY-QUEUE --use-millis
```

```
--producers 0 --consumers 1 --predeclared --routing-key MY-ROUTING-KEY --queue MY-QUEUE --use-millis
```

Try it without specifying `--use-millis` to see if you get output or not. In my home test environment, the Java VM running on my Thinkpad W520 produced a 13-digit number for `nanoTime`, while my desktop machine (with newer Intel CPU) produced a 14-digit number. The difference of these two numbers is negative, thus no stats output.