### PR TITLE
Support priority flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,6 @@
       <scope>test</scope>
     </dependency>
 
-
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>

--- a/src/main/java/com/rabbitmq/perf/LocalFilesMessageBodySource.java
+++ b/src/main/java/com/rabbitmq/perf/LocalFilesMessageBodySource.java
@@ -29,7 +29,7 @@ public class LocalFilesMessageBodySource implements MessageBodySource {
     private final String contentType;
 
     public LocalFilesMessageBodySource(List<String> filesNames, String contentType) throws IOException {
-        bodies = new ArrayList<byte[]>(filesNames.size());
+        bodies = new ArrayList<>(filesNames.size());
         for (String fileName : filesNames) {
             File file = new File(fileName.trim());
             if (!file.exists() || file.isDirectory()) {
@@ -56,7 +56,7 @@ public class LocalFilesMessageBodySource implements MessageBodySource {
     }
 
     @Override
-    public MessageBodyAndContentType create(int sequenceNumber) throws IOException {
+    public MessageBodyAndContentType create(int sequenceNumber) {
         return new MessageBodyAndContentType(
             bodies.get(sequenceNumber % bodies.size()), contentType
         );

--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -74,6 +74,8 @@ public class MulticastParams {
     private int queueSequenceFrom = -1;
     private int queueSequenceTo = -1;
 
+    private Map<String, Object> messageProperties = null;
+
     private TopologyHandler topologyHandler;
 
     private int heartbeatSenderThreads = -1;
@@ -211,6 +213,10 @@ public class MulticastParams {
         this.consumerLatencyInMicroseconds = consumerLatencyInMicroseconds;
     }
 
+    public void setMessageProperties(Map<String, Object> messageProperties) {
+        this.messageProperties = messageProperties;
+    }
+
     public int getConsumerCount() {
         return consumerCount;
     }
@@ -331,7 +337,7 @@ public class MulticastParams {
                                                randomRoutingKey, flags, producerTxSize,
                                                producerRateLimit, producerMsgCount,
                                                confirm, confirmTimeout, messageBodySource,
-                                               tsp, stats, completionHandler);
+                                               tsp, stats, messageProperties, completionHandler);
         channel.addReturnListener(producer);
         channel.addConfirmListener(producer);
         this.topologyHandler.next();

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -106,6 +106,7 @@ public class PerfTest {
             String queueArgs         = strArg(cmd, "qa", null);
             int consumerLatencyInMicroseconds = intArg(cmd, 'L', 0);
             int heartbeatSenderThreads = intArg(cmd, "hst", -1);
+            String messageProperties = strArg(cmd, "mp", null);
 
             String uri               = strArg(cmd, 'h', "amqp://localhost");
             String urisParameter     = strArg(cmd, 'H', null);
@@ -202,12 +203,13 @@ public class PerfTest {
             p.setUseMillis(             useMillis);
             p.setBodyFiles(             bodyFiles == null ? null : asList(bodyFiles.split(",")));
             p.setBodyContentType(       bodyContentType);
-            p.setQueueArguments(queueArguments(queueArgs));
+            p.setQueueArguments(convertKeyValuePairs(queueArgs));
             p.setConsumerLatencyInMicroseconds(consumerLatencyInMicroseconds);
             p.setQueuePattern(queuePattern);
             p.setQueueSequenceFrom(from);
             p.setQueueSequenceTo(to);
             p.setHeartbeatSenderThreads(heartbeatSenderThreads);
+            p.setMessageProperties(convertKeyValuePairs(messageProperties));
 
             MulticastSet.CompletionHandler completionHandler = getCompletionHandler(p);
 
@@ -336,6 +338,7 @@ public class PerfTest {
         options.addOption(new Option("F", "queue-pattern-from",     true, "sequence start for queue pattern (included)"));
         options.addOption(new Option("T", "queue-pattern-to",       true, "sequence end for queue pattern (included)"));
         options.addOption(new Option("hst", "heartbeat-sender-threads",       true, "number of threads for producers and consumers heartbeat senders"));
+        options.addOption(new Option("mp", "message-properties",    true, "message properties as key/pair values, separated by commas"));
         return options;
     }
 
@@ -371,20 +374,20 @@ public class PerfTest {
         return asList(vals);
     }
 
-    private static Map<String, Object> queueArguments(String arg) {
+    private static Map<String, Object> convertKeyValuePairs(String arg) {
         if (arg == null || arg.trim().isEmpty()) {
             return null;
         }
-        Map<String, Object> queueArguments = new HashMap<>();
+        Map<String, Object> properties = new HashMap<>();
         for (String entry : arg.split(",")) {
             String [] keyValue = entry.split("=");
             try {
-                queueArguments.put(keyValue[0], Long.parseLong(keyValue[1]));
+                properties.put(keyValue[0], Long.parseLong(keyValue[1]));
             } catch(NumberFormatException e) {
-                queueArguments.put(keyValue[0], keyValue[1]);
+                properties.put(keyValue[0], keyValue[1]);
             }
         }
-        return queueArguments;
+        return properties;
     }
 
     private static String getExchangeName(CommandLine cmd, String def) {

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -364,7 +364,7 @@ public class PerfTest {
     }
 
     private static List<?> lstArg(CommandLine cmd, char opt) {
-        String[] vals = cmd.getOptionValues('f');
+        String[] vals = cmd.getOptionValues(opt);
         if (vals == null) {
             vals = new String[] {};
         }

--- a/src/main/java/com/rabbitmq/perf/Producer.java
+++ b/src/main/java/com/rabbitmq/perf/Producer.java
@@ -21,8 +21,14 @@ import com.rabbitmq.client.ConfirmListener;
 import com.rabbitmq.client.ReturnListener;
 
 import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -30,6 +36,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import static java.util.stream.Collectors.toMap;
 
 public class Producer extends ProducerConsumerBase implements Runnable, ReturnListener,
         ConfirmListener
@@ -63,7 +70,8 @@ public class Producer extends ProducerConsumerBase implements Runnable, ReturnLi
                     float rateLimit, int msgLimit,
                     long confirm, int confirmTimeout,
                     MessageBodySource messageBodySource,
-                    TimestampProvider tsp, Stats stats, MulticastSet.CompletionHandler completionHandler) {
+                    TimestampProvider tsp, Stats stats, Map<String, Object> messageProperties,
+                    MulticastSet.CompletionHandler completionHandler) {
         this.channel           = channel;
         this.exchangeName      = exchangeName;
         this.id                = id;
@@ -72,26 +80,15 @@ public class Producer extends ProducerConsumerBase implements Runnable, ReturnLi
         this.persistent        = flags.contains("persistent");
 
         Function<AMQP.BasicProperties.Builder, AMQP.BasicProperties.Builder> builderProcessor = Function.identity();
-        for (Object flag : flags) {
-            if (flag != null && flag.toString().startsWith("priority=")) {
-                final Integer priority = Integer.valueOf(flag.toString().substring(
-                    flag.toString().indexOf("=") + 1
-                ));
-                builderProcessor = builderProcessor.andThen(builder -> {
-                    builder.priority(priority);
-                    return builder;
-                });
-            }
-        }
         this.txSize            = txSize;
         this.rateLimit         = rateLimit;
         this.msgLimit          = msgLimit;
         this.messageBodySource = messageBodySource;
         if (tsp.isTimestampInHeader()) {
-            builderProcessor = builderProcessor.andThen(builder -> {
-                builder.headers(Collections.singletonMap(TIMESTAMP_HEADER, tsp.getCurrentTime()));
-                return builder;
-            });
+            builderProcessor = builderProcessor.andThen(builder -> builder.headers(Collections.singletonMap(TIMESTAMP_HEADER, tsp.getCurrentTime())));
+        }
+        if (messageProperties != null && !messageProperties.isEmpty()) {
+            builderProcessor = builderProcessorWithMessageProperties(messageProperties, builderProcessor);
         }
         if (confirm > 0) {
             this.confirmPool  = new Semaphore((int)confirm);
@@ -100,6 +97,108 @@ public class Producer extends ProducerConsumerBase implements Runnable, ReturnLi
         this.stats = stats;
         this.completionHandler = completionHandler;
         this.propertiesBuilderProcessor = builderProcessor;
+    }
+
+    private Function<AMQP.BasicProperties.Builder, AMQP.BasicProperties.Builder> builderProcessorWithMessageProperties(
+            Map<String, Object> messageProperties,
+            Function<AMQP.BasicProperties.Builder, AMQP.BasicProperties.Builder> builderProcessor) {
+        if (messageProperties.containsKey("contentType")) {
+            String value = messageProperties.get("contentType").toString();
+            builderProcessor = builderProcessor.andThen(builder -> builder.contentType(value));
+        }
+        if (messageProperties.containsKey("contentEncoding")) {
+            String value = messageProperties.get("contentEncoding").toString();
+            builderProcessor = builderProcessor.andThen(builder -> builder.contentEncoding(value));
+        }
+        if (messageProperties.containsKey("deliveryMode")) {
+            Integer value = ((Number) messageProperties.get("deliveryMode")).intValue();
+            builderProcessor = builderProcessor.andThen(builder -> builder.deliveryMode(value));
+        }
+        if (messageProperties.containsKey("priority")) {
+            Integer value = ((Number) messageProperties.get("priority")).intValue();
+            builderProcessor = builderProcessor.andThen(builder -> builder.priority(value));
+        }
+        if (messageProperties.containsKey("correlationId")) {
+            String value = messageProperties.get("correlationId").toString();
+            builderProcessor = builderProcessor.andThen(builder -> builder.correlationId(value));
+        }
+        if (messageProperties.containsKey("replyTo")) {
+            String value = messageProperties.get("replyTo").toString();
+            builderProcessor = builderProcessor.andThen(builder -> builder.replyTo(value));
+        }
+        if (messageProperties.containsKey("expiration")) {
+            String value = messageProperties.get("expiration").toString();
+            builderProcessor = builderProcessor.andThen(builder -> builder.expiration(value));
+        }
+        if (messageProperties.containsKey("messageId")) {
+            String value = messageProperties.get("messageId").toString();
+            builderProcessor = builderProcessor.andThen(builder -> builder.messageId(value));
+        }
+        if (messageProperties.containsKey("timestamp")) {
+            String value = messageProperties.get("timestamp").toString();
+            Date timestamp = Date.from(OffsetDateTime.parse(value).toInstant());
+            builderProcessor = builderProcessor.andThen(builder -> builder.timestamp(timestamp));
+        }
+        if (messageProperties.containsKey("type")) {
+            String value = messageProperties.get("type").toString();
+            builderProcessor = builderProcessor.andThen(builder -> builder.type(value));
+        }
+        if (messageProperties.containsKey("userId")) {
+            String value = messageProperties.get("userId").toString();
+            builderProcessor = builderProcessor.andThen(builder -> builder.userId(value));
+        }
+        if (messageProperties.containsKey("appId")) {
+            String value = messageProperties.get("appId").toString();
+            builderProcessor = builderProcessor.andThen(builder -> builder.appId(value));
+        }
+        if (messageProperties.containsKey("clusterId")) {
+            String value = messageProperties.get("clusterId").toString();
+            builderProcessor = builderProcessor.andThen(builder -> builder.clusterId(value));
+        }
+
+        final Map<String, Object> headers = messageProperties.entrySet().stream()
+            .filter(entry -> !isPropertyKey(entry.getKey()))
+            .collect(toMap(e -> e.getKey(), e -> e.getValue()));
+
+        if (!headers.isEmpty()) {
+            builderProcessor = builderProcessor.andThen(builder -> {
+                // we merge if there are already some headers
+                AMQP.BasicProperties properties = builder.build();
+                Map<String, Object> existingHeaders = properties.getHeaders();
+                if (existingHeaders != null && !existingHeaders.isEmpty()) {
+                    Map<String, Object> newHeaders = new HashMap<>();
+                    newHeaders.putAll(existingHeaders);
+                    newHeaders.putAll(headers);
+                    builder = builder.headers(newHeaders);
+                } else {
+                    builder = builder.headers(headers);
+                }
+                return builder;
+            });
+        }
+
+        return builderProcessor;
+    }
+
+    private static final Collection<String> MESSAGE_PROPERTIES_KEYS = Arrays.asList(
+        "contentType",
+        "contentEncoding",
+        "headers",
+        "deliveryMode",
+        "priority",
+        "correlationId",
+        "replyTo",
+        "expiration",
+        "messageId",
+        "timestamp",
+        "type",
+        "userId",
+        "appId",
+        "clusterId"
+    );
+
+    private boolean isPropertyKey(String key) {
+        return MESSAGE_PROPERTIES_KEYS.contains(key);
     }
 
     public void handleReturn(int replyCode,

--- a/src/test/java/com/rabbitmq/perf/ProducerTest.java
+++ b/src/test/java/com/rabbitmq/perf/ProducerTest.java
@@ -1,0 +1,149 @@
+// Copyright (c) 2017-Present Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.perf;
+
+import com.rabbitmq.client.AMQP.BasicProperties;
+import com.rabbitmq.client.Channel;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+public class ProducerTest {
+
+    @Mock
+    Channel channel;
+
+    @Captor
+    private ArgumentCaptor<BasicProperties> propertiesCaptor;
+
+    @Before
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void flagNone() throws Exception {
+        flagProducer().run();
+
+        verify(channel).basicPublish(anyString(), anyString(),
+            eq(false), eq(false), propertiesCaptor.capture(),
+            any(byte[].class)
+        );
+
+        assertThat(props().getDeliveryMode(), nullValue());
+        assertThat(props().getPriority(), nullValue());
+    }
+
+    @Test
+    public void flagPersistent() throws Exception {
+        flagProducer("persistent").run();
+
+        verify(channel).basicPublish(anyString(), anyString(),
+            eq(false), eq(false), propertiesCaptor.capture(),
+            any(byte[].class)
+        );
+
+        assertThat(props().getDeliveryMode(), is(2));
+        assertThat(props().getPriority(), nullValue());
+    }
+
+    @Test
+    public void flagMandatory() throws Exception {
+        flagProducer("mandatory").run();
+
+        verify(channel).basicPublish(anyString(), anyString(),
+            eq(true), eq(false), propertiesCaptor.capture(),
+            any(byte[].class)
+        );
+
+        assertThat(props().getDeliveryMode(), nullValue());
+        assertThat(props().getPriority(), nullValue());
+    }
+
+    @Test
+    public void flagPriority() throws Exception {
+        flagProducer("priority=10").run();
+
+        verify(channel).basicPublish(anyString(), anyString(),
+            eq(false), eq(false), propertiesCaptor.capture(),
+            any(byte[].class)
+        );
+
+        assertThat(props().getDeliveryMode(), nullValue());
+        assertThat(props().getPriority(), is(10));
+    }
+
+    @Test
+    public void flagPersistentMandatoryPriority() throws Exception {
+        flagProducer("persistent", "mandatory", "priority=10").run();
+
+        verify(channel).basicPublish(anyString(), anyString(),
+            eq(true), eq(false), propertiesCaptor.capture(),
+            any(byte[].class)
+        );
+
+        assertThat(props().getDeliveryMode(), is(2));
+        assertThat(props().getPriority(), is(10));
+    }
+
+    Producer flagProducer(String... flags) {
+        return new Producer(
+            channel, "exchange", "id", false,
+            asList(flags),
+            0, 0.0f, 1,
+            -1, 30,
+            new TimeSequenceMessageBodySource(new TimestampProvider(false, false), 1000),
+            new TimestampProvider(false, false),
+            stats(),
+            new MulticastSet.CompletionHandler() {
+
+                @Override
+                public void waitForCompletion() {
+                }
+
+                @Override
+                public void countDown() {
+                }
+            }
+        );
+    }
+
+    BasicProperties props() {
+        return propertiesCaptor.getValue();
+    }
+
+    private Stats stats() {
+        return new Stats(0) {
+
+            @Override
+            protected void report(long now) {
+
+            }
+        };
+    }
+}


### PR DESCRIPTION
Priority for sent messages can be specified with the -flag option, e.g.:

```
--flag priority=10
```

If other flags need to be supported, use --flag several times, e.g.:

```
--flag priority=10 --flag persistent
```

Fixes #62