### PR TITLE
Spreads producers and consumers across multiple queues based on a queue pattern

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-migrationsupport</artifactId>
       <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- for parameterized tests -->
@@ -133,6 +134,7 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,10 @@
     <metrics.version>3.2.5</metrics.version>
     <logback.version>1.2.3</logback.version>
     <jetty.version>9.4.7.v20170914</jetty.version>
-    <junit.version>4.12</junit.version>
+    <junit.jupiter.version>5.0.2</junit.jupiter.version>
+    <junit.platform.version>1.0.2</junit.platform.version>
+    <mockito.version>2.13.0</mockito.version>
+    <hamcrest.version>2.0.0.0</hamcrest.version>
 
     <!-- to sign artifacts when releasing -->
     <gpg.keyname>6026DFCA</gpg.keyname>
@@ -75,6 +78,7 @@
     <checksum.maven.plugin.version>1.6</checksum.maven.plugin.version>
     <maven.jar.plugin.version>3.0.2</maven.jar.plugin.version>
     <buildnumber.plugin.version>1.4</buildnumber.plugin.version>
+    <maven.surefire.plugin.version>2.19.1</maven.surefire.plugin.version>
 
     <!-- because of https://issues.apache.org/jira/browse/MRESOURCES-99 -->
     <build.timestamp>${maven.build.timestamp}</build.timestamp>
@@ -104,11 +108,54 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.jupiter.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- To avoid compiler warnings about @API annotations in JUnit code -->
+    <dependency>
+      <groupId>org.apiguardian</groupId>
+      <artifactId>apiguardian-api</artifactId>
+      <version>1.0.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- to support JUnit 4 rules -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-migrationsupport</artifactId>
+      <version>${junit.jupiter.version}</version>
+    </dependency>
+
+    <!-- for parameterized tests -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit.jupiter.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-junit</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -143,6 +190,19 @@
             <arg>-Xlint:unchecked</arg>
           </compilerArgs>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven.surefire.plugin.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-surefire-provider</artifactId>
+            <version>${junit.platform.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
       <plugin>

--- a/src/main/java/com/rabbitmq/perf/Consumer.java
+++ b/src/main/java/com/rabbitmq/perf/Consumer.java
@@ -20,6 +20,7 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
 import com.rabbitmq.client.ShutdownSignalException;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -112,7 +113,7 @@ public class Consumer extends ProducerConsumerBase implements Runnable {
         } catch (IOException e) {
             throw new RuntimeException(e);
         } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+            LoggerFactory.getLogger(getClass()).warn("Consumer thread has been interrupted");
         } catch (ShutdownSignalException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -556,7 +556,7 @@ public class MulticastParams {
             super(params);
             queues = new ArrayList<>(to - from + 1);
             for (int i = from; i <= to; i++) {
-                queues.add(queuePattern.replaceAll("\\$\\{i\\}", String.valueOf(i)));
+                queues.add(String.format(queuePattern, i));
             }
         }
 

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -151,6 +151,21 @@ public class PerfTest {
             factory.setRequestedFrameMax(frameMax);
             factory.setRequestedHeartbeat(heartbeat);
 
+            String queuePattern        = strArg(cmd, "qp", null);
+            int from                   = intArg(cmd, 'F', -1);
+            int to                     = intArg(cmd, 'T', -1);
+
+            if (queuePattern != null || from >= 0 || to >= 0) {
+                if (queuePattern == null || from < 0 || to < 0) {
+                    System.err.println("Queue pattern, from, and to options should all be set or none should be set");
+                    System.exit(1);
+                }
+                if (from > to) {
+                    System.err.println("'To' option should be more than or equals to 'from' option");
+                    System.exit(1);
+                }
+            }
+
             MulticastParams p = new MulticastParams();
             p.setAutoAck(               autoAck);
             p.setAutoDelete(            autoDelete);
@@ -185,6 +200,9 @@ public class PerfTest {
             p.setBodyContentType(       bodyContentType);
             p.setQueueArguments(queueArguments(queueArgs));
             p.setConsumerLatencyInMicroseconds(consumerLatencyInMicroseconds);
+            p.setQueuePattern(queuePattern);
+            p.setQueueSequenceFrom(from);
+            p.setQueueSequenceTo(to);
 
             MulticastSet set = new MulticastSet(stats, factory, p, testID, uris);
             set.run(true);
@@ -282,6 +300,10 @@ public class PerfTest {
         options.addOption(new Option("udsc", "use-default-ssl-context", false,"use JVM default SSL context"));
 
         options.addOption(new Option("v", "version",                false,"print version information"));
+
+        options.addOption(new Option("qp", "queue-pattern",         true, "queue name pattern for creating queues in sequence"));
+        options.addOption(new Option("F", "from",                   true, "sequence start (included)"));
+        options.addOption(new Option("T", "to",                     true, "sequence end (included)"));
         return options;
     }
 
@@ -321,7 +343,7 @@ public class PerfTest {
         if (arg == null || arg.trim().isEmpty()) {
             return null;
         }
-        Map<String, Object> queueArguments = new HashMap<String, Object>();
+        Map<String, Object> queueArguments = new HashMap<>();
         for (String entry : arg.split(",")) {
             String [] keyValue = entry.split("=");
             try {

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -302,8 +302,8 @@ public class PerfTest {
         options.addOption(new Option("v", "version",                false,"print version information"));
 
         options.addOption(new Option("qp", "queue-pattern",         true, "queue name pattern for creating queues in sequence"));
-        options.addOption(new Option("F", "from",                   true, "sequence start (included)"));
-        options.addOption(new Option("T", "to",                     true, "sequence end (included)"));
+        options.addOption(new Option("F", "queue-pattern-from",     true, "sequence start for queue pattern (included)"));
+        options.addOption(new Option("T", "queue-pattern-to",       true, "sequence end for queue pattern (included)"));
         return options;
     }
 

--- a/src/main/java/com/rabbitmq/perf/Producer.java
+++ b/src/main/java/com/rabbitmq/perf/Producer.java
@@ -143,7 +143,7 @@ public class Producer extends ProducerConsumerBase implements Runnable, ReturnLi
         try {
 
             while ((timeLimitMillis == 0 || now < startTime + timeLimitMillis) &&
-                   (msgLimit == 0 || msgCount < msgLimit)) {
+                   (msgLimit == 0 || msgCount < msgLimit) && !Thread.interrupted()) {
                 delay(now);
                 if (confirmPool != null) {
                     if (confirmTimeout < 0) {

--- a/src/test/java/com/rabbitmq/perf/LocalFilesMessageBodySourceTest.java
+++ b/src/test/java/com/rabbitmq/perf/LocalFilesMessageBodySourceTest.java
@@ -16,7 +16,8 @@
 package com.rabbitmq.perf;
 
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
@@ -25,18 +26,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-/**
- *
- */
+@EnableRuleMigrationSupport
 public class LocalFilesMessageBodySourceTest {
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
-    @Test public void createOneFileThatExists() throws Exception {
+    @Test
+    public void createOneFileThatExists() throws Exception {
         File file = folder.newFile("content.txt");
         String content = "dummy content";
         write(file, content);

--- a/src/test/java/com/rabbitmq/perf/SequenceTopologyHandlerTest.java
+++ b/src/test/java/com/rabbitmq/perf/SequenceTopologyHandlerTest.java
@@ -31,7 +31,7 @@ public class SequenceTopologyHandlerTest {
 
     @Test
     public void sequence() {
-        handler = new MulticastParams.SequenceTopologyHandler(null, 1, 5, "test-${i}");
+        handler = new MulticastParams.SequenceTopologyHandler(null, 1, 5, "test-%d");
         assertThat(handler.getQueueNames(), allOf(iterableWithSize(5), hasItems("test-1", "test-2", "test-3", "test-4", "test-5")));
 
         assertThat(handler.getRoutingKey(), is("test-1"));
@@ -56,7 +56,7 @@ public class SequenceTopologyHandlerTest {
 
     @Test
     public void reset() {
-        handler = new MulticastParams.SequenceTopologyHandler(null, 1, 100, "test-${i}");
+        handler = new MulticastParams.SequenceTopologyHandler(null, 1, 100, "test-%d");
         assertThat(handler.getQueueNames(), hasSize(100));
 
         assertThat(handler.getRoutingKey(), is("test-1"));
@@ -75,5 +75,11 @@ public class SequenceTopologyHandlerTest {
         handler.next();
         assertThat(handler.getQueueNamesForClient(), allOf(iterableWithSize(1), hasItem("test-2")));
         assertThat(handler.getRoutingKey(), is("test-2"));
+    }
+
+    @Test
+    public void format() {
+        handler = new MulticastParams.SequenceTopologyHandler(null, 1, 5, "test-%03d");
+        assertThat(handler.getQueueNames(), allOf(iterableWithSize(5), hasItems("test-001", "test-002", "test-003", "test-004", "test-005")));
     }
 }

--- a/src/test/java/com/rabbitmq/perf/SequenceTopologyHandlerTest.java
+++ b/src/test/java/com/rabbitmq/perf/SequenceTopologyHandlerTest.java
@@ -1,0 +1,79 @@
+// Copyright (c) 2018-Present Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.perf;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.iterableWithSize;
+
+public class SequenceTopologyHandlerTest {
+
+    MulticastParams.SequenceTopologyHandler handler;
+
+    @Test
+    public void sequence() {
+        handler = new MulticastParams.SequenceTopologyHandler(null, 1, 5, "test-${i}");
+        assertThat(handler.getQueueNames(), allOf(iterableWithSize(5), hasItems("test-1", "test-2", "test-3", "test-4", "test-5")));
+
+        assertThat(handler.getRoutingKey(), is("test-1"));
+        assertThat(handler.getQueueNamesForClient(), allOf(iterableWithSize(1), hasItem("test-1")));
+        assertThat(handler.getRoutingKey(), is("test-1"));
+        handler.next();
+        assertThat(handler.getQueueNamesForClient(), allOf(iterableWithSize(1), hasItem("test-2")));
+        assertThat(handler.getRoutingKey(), is("test-2"));
+        handler.next();
+        assertThat(handler.getQueueNamesForClient(), allOf(iterableWithSize(1), hasItem("test-3")));
+        assertThat(handler.getRoutingKey(), is("test-3"));
+        handler.next();
+        assertThat(handler.getQueueNamesForClient(), allOf(iterableWithSize(1), hasItem("test-4")));
+        assertThat(handler.getRoutingKey(), is("test-4"));
+        handler.next();
+        assertThat(handler.getQueueNamesForClient(), allOf(iterableWithSize(1), hasItem("test-5")));
+        assertThat(handler.getRoutingKey(), is("test-5"));
+        handler.next();
+        assertThat(handler.getQueueNamesForClient(), allOf(iterableWithSize(1), hasItem("test-1")));
+        assertThat(handler.getRoutingKey(), is("test-1"));
+    }
+
+    @Test
+    public void reset() {
+        handler = new MulticastParams.SequenceTopologyHandler(null, 1, 100, "test-${i}");
+        assertThat(handler.getQueueNames(), hasSize(100));
+
+        assertThat(handler.getRoutingKey(), is("test-1"));
+        assertThat(handler.getQueueNamesForClient(), allOf(iterableWithSize(1), hasItem("test-1")));
+        assertThat(handler.getRoutingKey(), is("test-1"));
+        handler.next();
+        assertThat(handler.getQueueNamesForClient(), allOf(iterableWithSize(1), hasItem("test-2")));
+        assertThat(handler.getRoutingKey(), is("test-2"));
+        handler.next();
+
+        handler.reset();
+
+        assertThat(handler.getRoutingKey(), is("test-1"));
+        assertThat(handler.getQueueNamesForClient(), allOf(iterableWithSize(1), hasItem("test-1")));
+        assertThat(handler.getRoutingKey(), is("test-1"));
+        handler.next();
+        assertThat(handler.getQueueNamesForClient(), allOf(iterableWithSize(1), hasItem("test-2")));
+        assertThat(handler.getRoutingKey(), is("test-2"));
+    }
+}

--- a/src/test/java/com/rabbitmq/perf/TopologyTest.java
+++ b/src/test/java/com/rabbitmq/perf/TopologyTest.java
@@ -1,0 +1,637 @@
+// Copyright (c) 2018-Present Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.perf;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.impl.AMQImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.IntStream.range;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.iterableWithSize;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class TopologyTest {
+
+    @Mock
+    ConnectionFactory cf;
+    @Mock
+    Connection c;
+    @Mock
+    Channel ch;
+    @Mock
+    Stats stats;
+
+    MulticastParams params;
+
+    @Captor
+    ArgumentCaptor<String> queueNameCaptor;
+    @Captor
+    ArgumentCaptor<String> routingKeyCaptor;
+    @Captor
+    ArgumentCaptor<String> consumerQueue;
+    @Captor
+    private ArgumentCaptor<byte[]> bodyCaptor;
+
+    static Stream<Arguments> messageSizeArguments() {
+        return Stream.of(
+            Arguments.of(0, 12),
+            Arguments.of(4000, 4000)
+        );
+    }
+
+    @BeforeEach
+    public void init() throws Exception {
+        initMocks(this);
+
+        when(cf.newConnection()).thenReturn(c);
+        when(c.createChannel()).thenReturn(ch);
+
+        params = new MulticastParams();
+    }
+
+    @Test
+    public void defaultParameters()
+        throws Exception {
+        when(ch.queueDeclare(eq(""), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+            .thenReturn(new AMQImpl.Queue.DeclareOk("", 0, 0));
+
+        MulticastSet set = getMulticastSet();
+
+        set.run();
+
+        verify(cf, times(1 + 1 + 1)).newConnection(); // consumers, producers, configuration (not used)
+        verify(c, times(1 + 1 + 1)).createChannel(); // queue configuration, consumer, producer
+        verify(ch, times(1))
+            .queueDeclare(eq(""), anyBoolean(), anyBoolean(), anyBoolean(), isNull());
+        verify(ch, times(1))
+            .queueBind(anyString(), eq("direct"), anyString());
+    }
+
+    @Test
+    public void nProducersAndConsumer()
+        throws Exception {
+        params.setConsumerCount(10);
+        params.setProducerCount(10);
+
+        when(ch.queueDeclare(eq(""), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+            .thenReturn(new AMQImpl.Queue.DeclareOk("", 0, 0));
+
+        MulticastSet set = getMulticastSet();
+
+        set.run();
+
+        verify(cf, times(10 + 10 + 1)).newConnection(); // consumers, producers, configuration (not used)
+        verify(c, times(10 + 10 + 10)).createChannel(); // queue configuration, consumer, producer
+        verify(ch, times(10))
+            .queueDeclare(eq(""), anyBoolean(), anyBoolean(), anyBoolean(), isNull());
+        verify(ch, times(10))
+            .queueBind(anyString(), eq("direct"), anyString());
+    }
+
+    // -x 1 -y 2 -u "throughput-test-1" -a --id "test 1"
+    @Test
+    public void producers1Consumers2QueueSpecified() throws Exception {
+        String queue = "throughput-test-1";
+        params.setConsumerCount(2);
+        params.setProducerCount(1);
+        params.setQueueNames(singletonList(queue));
+
+        when(ch.queueDeclare(eq(queue), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+            .thenReturn(new AMQImpl.Queue.DeclareOk(queue, 0, 0));
+
+        MulticastSet set = getMulticastSet();
+
+        set.run();
+
+        verify(cf, times(2 + 1 + 1)).newConnection(); // consumers, producers, configuration (not used)
+        verify(c, times(2 + 2 + 1)).createChannel(); // queue configuration, consumer, producer
+        verify(ch, times(2))
+            .queueDeclare(eq(queue), anyBoolean(), anyBoolean(), anyBoolean(), isNull());
+        verify(ch, times(2))
+            .queueBind(eq(queue), eq("direct"), anyString());
+    }
+
+    // -x 2 -y 4 -u "throughput-test-2" -a --id "test 2"
+    @Test
+    public void producers2Consumers4QueueSpecified() throws Exception {
+        String queue = "throughput-test-2";
+        params.setConsumerCount(4);
+        params.setProducerCount(2);
+        params.setQueueNames(singletonList(queue));
+
+        when(ch.queueDeclare(eq(queue), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+            .thenReturn(new AMQImpl.Queue.DeclareOk(queue, 0, 0));
+
+        MulticastSet set = getMulticastSet();
+
+        set.run();
+
+        verify(cf, times(4 + 2 + 1)).newConnection(); // consumers, producers, configuration (not used)
+        verify(c, times(4 + 4 + 2)).createChannel(); // queue configuration, consumer, producer
+        verify(ch, times(4))
+            .queueDeclare(eq(queue), anyBoolean(), anyBoolean(), anyBoolean(), isNull());
+        verify(ch, times(4))
+            .queueBind(eq(queue), eq("direct"), anyString());
+    }
+
+    // -x 1 -y 2 -u "throughput-test-4" --id "test 4" -s 4000
+    @ParameterizedTest
+    @MethodSource("messageSizeArguments")
+    public void messageIsPublishedWithExpectedMessageSize(int requestedSize, int actualSize)
+        throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        when(ch.queueDeclare(eq(""), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+            .thenReturn(new AMQImpl.Queue.DeclareOk("", 0, 0));
+        doAnswer(invocation -> {
+            latch.countDown();
+            return null;
+        }).when(ch).basicPublish(anyString(), anyString(),
+            anyBoolean(), eq(false),
+            any(), bodyCaptor.capture());
+
+        params.setMinMsgSize(requestedSize);
+        MulticastSet set = getMulticastSet(new InterruptThreadHandler(latch));
+
+        set.run();
+
+        verify(ch, atLeastOnce())
+            .basicPublish(anyString(), anyString(),
+                anyBoolean(), eq(false),
+                any(), any(byte[].class)
+            );
+
+        assertThat(bodyCaptor.getValue().length, is(actualSize));
+    }
+
+    // -x 1 -y 2 -u "throughput-test-7" --id "test-7" -f persistent --multi-ack-every 200 -q 500
+    @Test
+    public void qosIsSetOnTheChannel() throws Exception {
+        when(ch.queueDeclare(eq(""), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+            .thenReturn(new AMQImpl.Queue.DeclareOk("", 0, 0));
+
+        params.setChannelPrefetch(500);
+
+        MulticastSet set = getMulticastSet();
+
+        set.run();
+
+        verify(cf, times(1 + 1 + 1)).newConnection(); // consumers, producers, configuration (not used)
+        verify(c, times(1 + 1 + 1)).createChannel(); // queue configuration, consumer, producer
+        verify(ch, times(1))
+            .queueDeclare(eq(""), anyBoolean(), anyBoolean(), anyBoolean(), isNull());
+        verify(ch, times(1))
+            .queueBind(anyString(), eq("direct"), anyString());
+        verify(ch, times(1))
+            .basicQos(500, true);
+    }
+
+    // -y 0 -p -u "throughput-test-14" -s 1000 -C 1000000 --id "test-14" -f persistent
+    @Test
+    public void prePopulateQueuePreDeclaredProducerOnlyRun() throws Exception {
+        String queue = "throughput-test-14";
+        params.setConsumerCount(0);
+        params.setProducerCount(1);
+        params.setQueueNames(singletonList(queue));
+        params.setPredeclared(true);
+
+        when(ch.queueDeclare(eq(queue), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+            .thenReturn(new AMQImpl.Queue.DeclareOk(queue, 0, 0));
+
+        MulticastSet set = getMulticastSet();
+
+        set.run();
+
+        verify(cf, times(1 + 1)).newConnection(); // configuration and producer
+        verify(c, atLeast(1 + 1)).createChannel(); // configuration, producer, and checks
+        verify(ch, never()) // shouldn't be called, pre-declared is true
+            .queueDeclare(eq(queue), anyBoolean(), anyBoolean(), anyBoolean(), isNull());
+        verify(ch, times(1))
+            .queueBind(eq(queue), eq("direct"), anyString());
+    }
+
+    // -x0 -y10 -p -u "throughput-test-14" --id "test-15"
+    @Test
+    public void preDeclaredOnlyConsumers() throws Exception {
+        String queue = "throughput-test-14";
+        params.setConsumerCount(10);
+        params.setProducerCount(0);
+        params.setQueueNames(singletonList(queue));
+        params.setPredeclared(true);
+
+        when(ch.queueDeclare(eq(queue), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+            .thenReturn(new AMQImpl.Queue.DeclareOk(queue, 0, 0));
+
+        MulticastSet set = getMulticastSet();
+
+        set.run();
+
+        verify(cf, times(10 + 1)).newConnection(); // consumers, configuration (not used)
+        verify(c, atLeast(10 + 10)).createChannel(); // configuration, consumers, and checks
+        verify(ch, never()) // shouldn't be called, pre-declared is true
+            .queueDeclare(eq(queue), anyBoolean(), anyBoolean(), anyBoolean(), isNull());
+        verify(ch, times(10))
+            .queueBind(eq(queue), eq("direct"), anyString());
+    }
+
+    // --producers 1 --consumers 0 --predeclared --routing-key rk --queue q --use-millis
+    @Test
+    public void differentMachinesProducer() throws Exception {
+        String queue = "q";
+        String routingKey = "rk";
+        params.setConsumerCount(0);
+        params.setProducerCount(1);
+        params.setQueueNames(singletonList(queue));
+        params.setRoutingKey(routingKey);
+        params.setPredeclared(true);
+
+        when(ch.queueDeclare(eq(queue), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+            .thenReturn(new AMQImpl.Queue.DeclareOk(queue, 0, 0));
+
+        MulticastSet set = getMulticastSet();
+
+        set.run();
+
+        verify(cf, times(1 + 1)).newConnection(); // configuration, producer
+        verify(c, atLeast(1 + 1)).createChannel(); // configuration, producer, checks
+        verify(ch, never()) // shouldn't be called, pre-declared is true
+            .queueDeclare(eq(queue), anyBoolean(), anyBoolean(), anyBoolean(), isNull());
+        verify(ch, times(1))
+            .queueBind(eq(queue), eq("direct"), eq(routingKey));
+    }
+
+    // --producers 0 --consumers 1 --predeclared --routing-key rk --queue q --use-millis
+    @Test
+    public void differentMachinesConsumer() throws Exception {
+        String queue = "q";
+        String routingKey = "rk";
+        params.setConsumerCount(1);
+        params.setProducerCount(0);
+        params.setQueueNames(singletonList(queue));
+        params.setRoutingKey(routingKey);
+        params.setPredeclared(true);
+
+        when(ch.queueDeclare(eq(queue), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+            .thenReturn(new AMQImpl.Queue.DeclareOk(queue, 0, 0));
+
+        MulticastSet set = getMulticastSet();
+
+        set.run();
+
+        verify(cf, times(1 + 1)).newConnection(); // consumer, configuration (not used)
+        verify(c, atLeast(1 + 1)).createChannel(); // configuration, consumer, checks
+        verify(ch, never()) // shouldn't be called, pre-declared is true
+            .queueDeclare(eq(queue), anyBoolean(), anyBoolean(), anyBoolean(), isNull());
+        verify(ch, times(1))
+            .queueBind(eq(queue), eq("direct"), eq(routingKey));
+    }
+
+    // --queue-pattern 'perf-test-${i}' --from 1 --to 100
+    @Test
+    public void sequenceQueuesDefinition1to100() throws Exception {
+        String queuePrefix = "perf-test-";
+        params.setQueuePattern(queuePrefix + "${i}");
+        params.setQueueSequenceFrom(1);
+        params.setQueueSequenceTo(100);
+
+        when(ch.queueDeclare(queueNameCaptor.capture(), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+            .then(invocation -> new AMQImpl.Queue.DeclareOk(invocation.getArgument(0), 0, 0));
+
+        MulticastSet set = getMulticastSet();
+
+        set.run();
+
+        verify(cf, times(1 + 1 + 1)).newConnection(); // configuration, consumer, producer
+        verify(c, atLeast(1 + 1 + 1)).createChannel(); // configuration, producer, consumer, and checks
+        verify(ch, times(100))
+            .queueDeclare(startsWith(queuePrefix), anyBoolean(), anyBoolean(), anyBoolean(), isNull());
+        verify(ch, times(100))
+            .queueBind(startsWith(queuePrefix), eq("direct"), routingKeyCaptor.capture());
+
+        assertThat(queueNameCaptor.getAllValues(), allOf(
+            iterableWithSize(100),
+            hasItems(queuePrefix + "1", queuePrefix + "2", queuePrefix + "100")
+        ));
+        assertThat(routingKeyCaptor.getAllValues(), allOf(
+            iterableWithSize(100),
+            hasItems(queuePrefix + "1", queuePrefix + "2", queuePrefix + "100")
+        ));
+    }
+
+    // --queue-pattern 'perf-test-${i}' --from 100 --to 500
+    @Test
+    public void sequenceQueuesDefinition100to500() throws Exception {
+        String queuePrefix = "perf-test-";
+        params.setQueuePattern(queuePrefix + "${i}");
+        params.setQueueSequenceFrom(100);
+        params.setQueueSequenceTo(500);
+
+        when(ch.queueDeclare(queueNameCaptor.capture(), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+            .then(invocation -> new AMQImpl.Queue.DeclareOk(invocation.getArgument(0), 0, 0));
+
+        MulticastSet set = getMulticastSet();
+
+        set.run();
+
+        verify(cf, times(1 + 1 + 1)).newConnection(); // configuration, consumer, producer
+        verify(c, atLeast(1 + 1 + 1)).createChannel(); // configuration, producer, consumer, and checks
+        verify(ch, times(401))
+            .queueDeclare(startsWith(queuePrefix), anyBoolean(), anyBoolean(), anyBoolean(), isNull());
+        verify(ch, times(401))
+            .queueBind(startsWith(queuePrefix), eq("direct"), routingKeyCaptor.capture());
+
+        assertThat(queueNameCaptor.getAllValues(), allOf(
+            iterableWithSize(401),
+            hasItems(queuePrefix + "100", queuePrefix + "101", queuePrefix + "499", queuePrefix + "500")
+        ));
+        assertThat(routingKeyCaptor.getAllValues(), allOf(
+            iterableWithSize(401),
+            hasItems(queuePrefix + "100", queuePrefix + "101", queuePrefix + "499", queuePrefix + "500")
+        ));
+    }
+
+    //  --queue-pattern 'perf-test-${i}' --from 502 --to 5001
+    @Test
+    public void sequenceQueuesDefinition502to5001() throws Exception {
+        String queuePrefix = "perf-test-";
+        params.setQueuePattern(queuePrefix + "${i}");
+        params.setQueueSequenceFrom(502);
+        params.setQueueSequenceTo(5001);
+
+        when(ch.queueDeclare(queueNameCaptor.capture(), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+            .then(invocation -> new AMQImpl.Queue.DeclareOk(invocation.getArgument(0), 0, 0));
+
+        MulticastSet set = getMulticastSet();
+
+        set.run();
+
+        verify(cf, times(1 + 1 + 1)).newConnection(); // configuration, consumer, producer
+        verify(c, atLeast(1 + 1 + 1)).createChannel(); // configuration, producer, consumer, and checks
+        verify(ch, times(4500))
+            .queueDeclare(startsWith(queuePrefix), anyBoolean(), anyBoolean(), anyBoolean(), isNull());
+        verify(ch, times(4500))
+            .queueBind(startsWith(queuePrefix), eq("direct"), routingKeyCaptor.capture());
+
+        assertThat(queueNameCaptor.getAllValues(), allOf(
+            iterableWithSize(4500),
+            hasItems(queuePrefix + "502", queuePrefix + "503", queuePrefix + "5000", queuePrefix + "5001"),
+            not(hasItems(queuePrefix + "501"))
+        ));
+        assertThat(routingKeyCaptor.getAllValues(), allOf(
+            iterableWithSize(4500),
+            hasItems(queuePrefix + "502", queuePrefix + "503", queuePrefix + "5000", queuePrefix + "5001"),
+            not(hasItems(queuePrefix + "501"))
+        ));
+    }
+
+    // --queue-pattern 'perf-test-${i}' --from 1 --to 100 --producers 10 --consumers 0
+    @Test
+    public void sequenceMoreQueuesThanProducers() throws Exception {
+        String queuePrefix = "perf-test-";
+        params.setConsumerCount(0);
+        params.setProducerCount(10);
+        params.setQueuePattern(queuePrefix + "${i}");
+        params.setQueueSequenceFrom(1);
+        params.setQueueSequenceTo(100);
+
+        when(ch.queueDeclare(queueNameCaptor.capture(), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+            .then(invocation -> new AMQImpl.Queue.DeclareOk(invocation.getArgument(0), 0, 0));
+
+        // we wait for 1 K messages to be sent
+        // hopefully there will be messages of all the producers to assert against all routing key values
+        CountDownLatch latchPublishing = new CountDownLatch(1000);
+        doAnswer(invocation -> {
+            latchPublishing.countDown();
+            return null;
+        }).when(ch).basicPublish(eq("direct"), routingKeyCaptor.capture(),
+            anyBoolean(), eq(false),
+            any(), any(byte[].class));
+
+        MulticastSet set = getMulticastSet(new InterruptThreadHandler(latchPublishing));
+
+        set.run();
+
+        verify(cf, times(1 + 0 + 10)).newConnection(); // configuration, consumer, producer
+        verify(c, atLeast(1 + 10)).createChannel(); // configuration, producer, and checks
+        verify(ch, times(100))
+            .queueDeclare(startsWith(queuePrefix), anyBoolean(), anyBoolean(), anyBoolean(), isNull());
+        verify(ch, times(100))
+            .queueBind(startsWith(queuePrefix), eq("direct"), startsWith(queuePrefix));
+        verify(ch, never()).basicConsume(anyString(), anyBoolean(), any());
+
+        assertThat(routingKeyCaptor.getAllValues().stream().distinct().toArray(), allOf(
+            arrayWithSize(10),
+            arrayContainingInAnyOrder(range(1, 11).mapToObj(i -> queuePrefix + i).toArray())
+        ));
+    }
+
+    // --queue-pattern 'perf-test-${i}' --from 1 --to 10 --producers 15 --consumers 30
+    @Test
+    public void sequenceProducersAndConsumersSpread() throws Exception {
+        String queuePrefix = "perf-test-";
+        params.setConsumerCount(30);
+        params.setProducerCount(15);
+        params.setQueuePattern(queuePrefix + "${i}");
+        params.setQueueSequenceFrom(1);
+        params.setQueueSequenceTo(10);
+
+        when(ch.queueDeclare(queueNameCaptor.capture(), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+            .then(invocation -> new AMQImpl.Queue.DeclareOk(invocation.getArgument(0), 0, 0));
+
+        // we wait for 1 K messages to be sent
+        // hopefully there will be messages of all the producers to assert against all routing key values
+        CountDownLatch latchPublishing = new CountDownLatch(1000);
+        doAnswer(invocation -> {
+            latchPublishing.countDown();
+            return null;
+        }).when(ch).basicPublish(eq("direct"), routingKeyCaptor.capture(),
+            anyBoolean(), eq(false),
+            any(), any(byte[].class));
+
+        MulticastSet set = getMulticastSet(new InterruptThreadHandler(latchPublishing));
+
+        set.run();
+
+        verify(cf, times(1 + 30 + 15)).newConnection(); // configuration, consumers, producers
+        verify(c, atLeast(1 + 30 + 15)).createChannel(); // configuration, producers, consumers, and checks
+        verify(ch, times(10))
+            .queueDeclare(startsWith(queuePrefix), anyBoolean(), anyBoolean(), anyBoolean(), isNull());
+        verify(ch, times(10))
+            .queueBind(startsWith(queuePrefix), eq("direct"), startsWith(queuePrefix));
+        verify(ch, times(30)).basicConsume(consumerQueue.capture(), anyBoolean(), any());
+
+        assertThat(routingKeyCaptor.getAllValues().stream().distinct().toArray(), allOf(
+            arrayWithSize(10),
+            arrayContainingInAnyOrder(range(1, 11).mapToObj(i -> queuePrefix + i).toArray())
+        ));
+
+        assertThat(routingKeyCaptor.getAllValues().stream().distinct().toArray(), allOf(
+            arrayWithSize(10),
+            arrayContainingInAnyOrder(range(1, 11).mapToObj(i -> queuePrefix + i).toArray())
+        ));
+
+        // the captor received all the queues that have at least one consumer
+        // let's count the number of consumers per queue
+        Map<String, Integer> queueToConsumerNumber = consumerQueue.getAllValues().stream()
+            .collect(toMap(queue -> queue, queue -> 1, (oldValue, newValue) -> ++oldValue));
+
+        // there are consumers on all queues
+        assertThat(queueToConsumerNumber.keySet().toArray(), allOf(
+            arrayWithSize(10),
+            arrayContainingInAnyOrder(range(1, 11).mapToObj(i -> queuePrefix + i).toArray())
+        ));
+
+        // there are 3 consumers per queue
+        assertThat(queueToConsumerNumber.values().stream().distinct().toArray(), allOf(
+            arrayWithSize(1),
+            arrayContaining(3)
+        ));
+    }
+
+    // --queue-pattern 'perf-test-${i}' --from 101 --to 110 --producers 0 --consumers 110
+    @Test
+    public void sequenceConsumersSpread() throws Exception {
+        String queuePrefix = "perf-test-";
+        params.setConsumerCount(110);
+        params.setProducerCount(0);
+        params.setQueuePattern(queuePrefix + "${i}");
+        params.setQueueSequenceFrom(101);
+        params.setQueueSequenceTo(110);
+
+        when(ch.queueDeclare(queueNameCaptor.capture(), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+            .then(invocation -> new AMQImpl.Queue.DeclareOk(invocation.getArgument(0), 0, 0));
+
+        // stopping when all consumers are registered
+        CountDownLatch latch = new CountDownLatch(110);
+        doAnswer(invocation -> {
+            latch.countDown();
+            return UUID.randomUUID().toString();
+        }).when(ch).basicConsume(consumerQueue.capture(), anyBoolean(), any());
+
+        MulticastSet set = getMulticastSet(new InterruptThreadHandler(latch));
+
+        set.run();
+
+        verify(cf, times(1 + 110 + 0)).newConnection(); // configuration, consumers, producers
+        verify(c, atLeast(1 + 110 + 0)).createChannel(); // configuration, producers, consumers, and checks
+        verify(ch, times(10))
+            .queueDeclare(startsWith(queuePrefix), anyBoolean(), anyBoolean(), anyBoolean(), isNull());
+        verify(ch, times(10))
+            .queueBind(startsWith(queuePrefix), eq("direct"), startsWith(queuePrefix));
+        verify(ch, times(110)).basicConsume(anyString(), anyBoolean(), any());
+
+        // the captor received all the queues that have at least one consumer
+        // let's count the number of consumers per queue
+        Map<String, Integer> queueToConsumerNumber = consumerQueue.getAllValues().stream()
+            .collect(toMap(queue -> queue, queue -> 1, (oldValue, newValue) -> ++oldValue));
+
+        // there are consumers on all queues
+        assertThat(queueToConsumerNumber.keySet().toArray(), allOf(
+            arrayWithSize(10),
+            arrayContainingInAnyOrder(range(101, 111).mapToObj(i -> queuePrefix + i).toArray())
+        ));
+
+        // there are 11 consumers per queue
+        assertThat(queueToConsumerNumber.values().stream().distinct().toArray(), allOf(
+            arrayWithSize(1),
+            arrayContaining(11)
+        ));
+    }
+
+    private MulticastSet getMulticastSet() {
+        return getMulticastSet(new NoOpThreadHandler());
+    }
+
+    private MulticastSet getMulticastSet(MulticastSet.ThreadHandler threadHandler) {
+        MulticastSet set = new MulticastSet(
+            stats, cf, params, singletonList("amqp://localhost")
+        );
+
+        set.setThreadHandler(threadHandler);
+        return set;
+    }
+
+    static class NoOpThreadHandler implements MulticastSet.ThreadHandler {
+
+        @Override
+        public void start(Thread thread) {
+        }
+
+        @Override
+        public void waitForCompletion(Thread thread) {
+        }
+    }
+
+    static class InterruptThreadHandler implements MulticastSet.ThreadHandler {
+
+        final CountDownLatch[] latches;
+
+        InterruptThreadHandler(CountDownLatch... latches) {
+            this.latches = latches;
+        }
+
+        @Override
+        public void start(Thread thread) {
+            thread.start();
+        }
+
+        @Override
+        public void waitForCompletion(Thread thread) throws InterruptedException {
+            for (CountDownLatch latch : latches) {
+                latch.await(1, TimeUnit.SECONDS);
+            }
+            thread.interrupt();
+            thread.join(500);
+        }
+    }
+}

--- a/src/test/java/com/rabbitmq/perf/TopologyTest.java
+++ b/src/test/java/com/rabbitmq/perf/TopologyTest.java
@@ -336,11 +336,11 @@ public class TopologyTest {
             .queueBind(eq(queue), eq("direct"), eq(routingKey));
     }
 
-    // --queue-pattern 'perf-test-${i}' --from 1 --to 100
+    // --queue-pattern 'perf-test-%d' --queue-pattern-from 1 --queue-pattern-to 100
     @Test
     public void sequenceQueuesDefinition1to100() throws Exception {
         String queuePrefix = "perf-test-";
-        params.setQueuePattern(queuePrefix + "${i}");
+        params.setQueuePattern(queuePrefix + "%d");
         params.setQueueSequenceFrom(1);
         params.setQueueSequenceTo(100);
 
@@ -368,11 +368,11 @@ public class TopologyTest {
         ));
     }
 
-    // --queue-pattern 'perf-test-${i}' --from 100 --to 500
+    // --queue-pattern 'perf-test-%d' --queue-pattern-from 100 --queue-pattern-to 500
     @Test
     public void sequenceQueuesDefinition100to500() throws Exception {
         String queuePrefix = "perf-test-";
-        params.setQueuePattern(queuePrefix + "${i}");
+        params.setQueuePattern(queuePrefix + "%d");
         params.setQueueSequenceFrom(100);
         params.setQueueSequenceTo(500);
 
@@ -400,11 +400,11 @@ public class TopologyTest {
         ));
     }
 
-    //  --queue-pattern 'perf-test-${i}' --from 502 --to 5001
+    //  --queue-pattern 'perf-test-%d' --queue-pattern-from 502 --queue-pattern-to 5001
     @Test
     public void sequenceQueuesDefinition502to5001() throws Exception {
         String queuePrefix = "perf-test-";
-        params.setQueuePattern(queuePrefix + "${i}");
+        params.setQueuePattern(queuePrefix + "%d");
         params.setQueueSequenceFrom(502);
         params.setQueueSequenceTo(5001);
 
@@ -434,13 +434,13 @@ public class TopologyTest {
         ));
     }
 
-    // --queue-pattern 'perf-test-${i}' --from 1 --to 100 --producers 10 --consumers 0
+    // --queue-pattern 'perf-test-%d' --queue-pattern-from 1 --queue-pattern-to 100 --producers 10 --consumers 0
     @Test
     public void sequenceMoreQueuesThanProducers() throws Exception {
         String queuePrefix = "perf-test-";
         params.setConsumerCount(0);
         params.setProducerCount(10);
-        params.setQueuePattern(queuePrefix + "${i}");
+        params.setQueuePattern(queuePrefix + "%d");
         params.setQueueSequenceFrom(1);
         params.setQueueSequenceTo(100);
 
@@ -475,13 +475,13 @@ public class TopologyTest {
         ));
     }
 
-    // --queue-pattern 'perf-test-${i}' --from 1 --to 10 --producers 15 --consumers 30
+    // --queue-pattern 'perf-test-%d' --queue-pattern-from 1 --queue-pattern-to 10 --producers 15 --consumers 30
     @Test
     public void sequenceProducersAndConsumersSpread() throws Exception {
         String queuePrefix = "perf-test-";
         params.setConsumerCount(30);
         params.setProducerCount(15);
-        params.setQueuePattern(queuePrefix + "${i}");
+        params.setQueuePattern(queuePrefix + "%d");
         params.setQueueSequenceFrom(1);
         params.setQueueSequenceTo(10);
 
@@ -538,13 +538,13 @@ public class TopologyTest {
         ));
     }
 
-    // --queue-pattern 'perf-test-${i}' --from 101 --to 110 --producers 0 --consumers 110
+    // --queue-pattern 'perf-test-%d' --queue-pattern-from 101 --queue-pattern-to 110 --producers 0 --consumers 110
     @Test
     public void sequenceConsumersSpread() throws Exception {
         String queuePrefix = "perf-test-";
         params.setConsumerCount(110);
         params.setProducerCount(0);
-        params.setQueuePattern(queuePrefix + "${i}");
+        params.setQueuePattern(queuePrefix + "%d");
         params.setQueueSequenceFrom(101);
         params.setQueueSequenceTo(110);
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="error">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
This allows creating a sequence of queues and balancing the producers
and the consumers across those queues.

E.g. `--queue-pattern 'perf-test-${i}' --from 1 --to 100 --producers 150 --consumers 300`

This will run 2 producers per `perf-test-[1..50]` queue, and 1 producer
per `perf-test-[51..100]` queue, for a total of 150 producers.
There will be 3 consumers per `perf-test-[1..100]` queue, for a total of 300 consumers.

This commit contains also a bit of Java 8 refactoring and an upgrade to JUnit 5.

Fixes #64