### PR TITLE
Use exec to run java

### DIFF
--- a/scripts/runjava
+++ b/scripts/runjava
@@ -92,4 +92,4 @@ if $cygwin; then
 	CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
 fi
 
-"${JAVA_HOME}/bin/java" ${JAVA_OPTS} -cp "$CLASSPATH" "$@"
+exec "${JAVA_HOME}/bin/java" ${JAVA_OPTS} -cp "$CLASSPATH" "$@"


### PR DESCRIPTION
This way the PID returned to the parent process will be the PID of the JVM, not of the shell running the script