### PR TITLE
Rationalize threads usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,12 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-migrationsupport</artifactId>
       <version>${junit.jupiter.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -76,6 +76,8 @@ public class MulticastParams {
 
     private TopologyHandler topologyHandler;
 
+    private int heartbeatSenderThreads = -1;
+
     public void setExchangeType(String exchangeType) {
         this.exchangeType = exchangeType;
     }
@@ -287,6 +289,14 @@ public class MulticastParams {
 
     public int getQueueSequenceTo() {
         return queueSequenceTo;
+    }
+
+    public void setHeartbeatSenderThreads(int heartbeatSenderThreads) {
+        this.heartbeatSenderThreads = heartbeatSenderThreads;
+    }
+
+    public int getHeartbeatSenderThreads() {
+        return heartbeatSenderThreads <= 0 ? producerCount + consumerCount : this.heartbeatSenderThreads;
     }
 
     public Producer createProducer(Connection connection, Stats stats) throws IOException {

--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -343,7 +343,7 @@ public class MulticastParams {
         TimestampProvider tsp = new TimestampProvider(useMillis, timestampInHeader);
         Consumer consumer = new Consumer(channel, this.topologyHandler.getRoutingKey(), generatedQueueNames,
                                          consumerTxSize, autoAck, multiAckEvery,
-                                         stats, consumerRateLimit, consumerMsgCount, timeLimit,
+                                         stats, consumerRateLimit, consumerMsgCount,
                                          consumerLatencyInMicroseconds, tsp);
         this.topologyHandler.next();
         return consumer;

--- a/src/main/java/com/rabbitmq/perf/MulticastSet.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastSet.java
@@ -220,10 +220,7 @@ public class MulticastSet {
             if (nbThreads <= 0) {
                 return create(() -> Executors.newSingleThreadExecutor(new NamedThreadFactory(name)));
             } else {
-                return create(() -> new ThreadPoolExecutor(nbThreads, nbThreads,
-                    60L, TimeUnit.SECONDS,
-                    new SynchronousQueue<>(),
-                    new NamedThreadFactory(name)));
+                return create(() -> Executors.newFixedThreadPool(nbThreads, new NamedThreadFactory(name)));
             }
         }
 

--- a/src/main/java/com/rabbitmq/perf/MulticastSet.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastSet.java
@@ -22,10 +22,23 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Random;
-import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+import static java.lang.Math.min;
+import static java.lang.String.format;
 
 public class MulticastSet {
 
@@ -37,7 +50,7 @@ public class MulticastSet {
 
     private final Random random = new Random();
 
-    private ThreadHandler threadHandler = new DefaultThreadHandler();
+    private ThreadingHandler threadingHandler = new DefaultThreadingHandler();
 
     public MulticastSet(Stats stats, ConnectionFactory factory,
         MulticastParams params, List<String> uris) {
@@ -55,73 +68,102 @@ public class MulticastSet {
         this.params.init();
     }
 
-    public void run() throws IOException, InterruptedException, TimeoutException, NoSuchAlgorithmException, KeyManagementException, URISyntaxException {
+    public void run()
+        throws IOException, InterruptedException, TimeoutException, NoSuchAlgorithmException, KeyManagementException, URISyntaxException, ExecutionException {
         run(false);
     }
 
     public void run(boolean announceStartup)
-        throws IOException, InterruptedException, TimeoutException, NoSuchAlgorithmException, KeyManagementException, URISyntaxException {
+        throws IOException, InterruptedException, TimeoutException, NoSuchAlgorithmException, KeyManagementException, URISyntaxException, ExecutionException {
+
+        ScheduledExecutorService heartbeatSenderExecutorService = this.threadingHandler.scheduledExecutorService(
+            "perf-test-heartbeat-sender-",
+            this.params.getHeartbeatSenderThreads()
+        );
+        factory.setHeartbeatExecutor(heartbeatSenderExecutorService);
 
         setUri();
-        Connection conn = factory.newConnection();
+        Connection conn = factory.newConnection("perf-test-configuration");
         params.configureAllQueues(conn);
         conn.close();
 
         this.params.resetTopologyHandler();
 
-        Thread[] consumerThreads = new Thread[params.getConsumerThreadCount()];
+        AgentState[] agentStates = new AgentState[params.getConsumerThreadCount()];
         Connection[] consumerConnections = new Connection[params.getConsumerCount()];
         for (int i = 0; i < consumerConnections.length; i++) {
             if (announceStartup) {
                 System.out.println("id: " + testID + ", starting consumer #" + i);
             }
             setUri();
-            conn = factory.newConnection();
+
+            ExecutorService executorService = this.threadingHandler.executorService(
+                format("perf-test-consumer-%s-worker-", i),
+                nbThreadsForConsumer(this.params)
+            );
+            factory.setSharedExecutor(executorService);
+
+            conn = factory.newConnection("perf-test-consumer-" + i);
             consumerConnections[i] = conn;
             for (int j = 0; j < params.getConsumerChannelCount(); j++) {
                 if (announceStartup) {
                     System.out.println("id: " + testID + ", starting consumer #" + i + ", channel #" + j);
                 }
-                Thread t = new Thread(params.createConsumer(conn, stats));
-                consumerThreads[(i * params.getConsumerChannelCount()) + j] = t;
+
+                AgentState agentState = new AgentState();
+                agentState.runnable = params.createConsumer(conn, stats);
+                agentStates[(i * params.getConsumerChannelCount()) + j] = agentState;
             }
         }
 
         this.params.resetTopologyHandler();
 
-        Thread[] producerThreads = new Thread[params.getProducerThreadCount()];
+        AgentState[] producerStates = new AgentState[params.getProducerThreadCount()];
         Connection[] producerConnections = new Connection[params.getProducerCount()];
+        // producers don't need an executor service, as they don't have any consumers
+        // this consumer should never be asked to create any threads
+        ExecutorService executorServiceForProducersConsumers = this.threadingHandler.executorService(
+            "perf-test-producers-worker-", 0
+        );
+        factory.setSharedExecutor(executorServiceForProducersConsumers);
         for (int i = 0; i < producerConnections.length; i++) {
             if (announceStartup) {
                 System.out.println("id: " + testID + ", starting producer #" + i);
             }
             setUri();
-            conn = factory.newConnection();
+            conn = factory.newConnection("perf-test-producer-i");
             producerConnections[i] = conn;
             for (int j = 0; j < params.getProducerChannelCount(); j++) {
                 if (announceStartup) {
                     System.out.println("id: " + testID + ", starting producer #" + i + ", channel #" + j);
                 }
-                Thread t = new Thread(params.createProducer(conn, stats));
-                producerThreads[(i * params.getProducerChannelCount()) + j] = t;
+                AgentState agentState = new AgentState();
+                agentState.runnable = params.createProducer(conn, stats);
+                producerStates[(i * params.getProducerChannelCount()) + j] = agentState;
             }
         }
 
-        for (Thread consumerThread : consumerThreads) {
-            this.threadHandler.start(consumerThread);
+        ExecutorService consumerStarterExecutorService = this.threadingHandler.executorService(
+            "perf-test-consumers-starter-", 1
+        );
+        for (AgentState agentState : agentStates) {
+            agentState.task = consumerStarterExecutorService.submit(agentState.runnable);
             if(params.getConsumerSlowStart()) {
-            	System.out.println("Delaying start by 1 second because -S/--slow-start was requested");
-            	Thread.sleep(1000);
+                System.out.println("Delaying start by 1 second because -S/--slow-start was requested");
+                Thread.sleep(1000);
             }
         }
 
-        for (Thread producerThread : producerThreads) {
-            this.threadHandler.start(producerThread);
+        ExecutorService producersExecutorService = this.threadingHandler.executorService(
+            "perf-test-producer-", producerStates.length
+        );
+        for (AgentState producerState : producerStates) {
+            producerState.task = producersExecutorService.submit(producerState.runnable);
         }
 
         int count = 1; // counting the threads
-        for (int i = 0; i < producerThreads.length; i++) {
-            this.threadHandler.waitForCompletion(producerThreads[i]);
+        for (int i = 0; i < producerStates.length; i++) {
+            producerStates[i].task.get();
             if(count % params.getProducerChannelCount() == 0) {
                 // this is the end of a group of threads on the same connection,
                 // closing the connection
@@ -131,8 +173,8 @@ public class MulticastSet {
         }
 
         count = 1; // counting the threads
-        for (int i = 0; i < consumerThreads.length; i++) {
-            this.threadHandler.waitForCompletion(consumerThreads[i]);
+        for (int i = 0; i < agentStates.length; i++) {
+            agentStates[i].task.get();
             if(count % params.getConsumerChannelCount() == 0) {
                 // this is the end of a group of threads on the same connection,
                 // closing the connection
@@ -140,10 +182,18 @@ public class MulticastSet {
             }
             count++;
         }
+
+        this.threadingHandler.shutdown();
     }
 
-    public void setThreadHandler(ThreadHandler threadHandler) {
-        this.threadHandler = threadHandler;
+    // from Java Client ConsumerWorkService
+    public final static int DEFAULT_CONSUMER_WORK_SERVICE_THREAD_POOL_SIZE = Runtime.getRuntime().availableProcessors() * 2;
+
+    protected static int nbThreadsForConsumer(MulticastParams params) {
+        // for backward compatibility, the thread pool should large enough to dedicate
+        // one thread for each channel when channel number is <= DEFAULT_CONSUMER_WORK_SERVICE_THREAD_POOL_SIZE
+        // Above this number, we stick to DEFAULT_CONSUMER_WORK_SERVICE_THREAD_POOL_SIZE
+        return min(params.getConsumerChannelCount(), DEFAULT_CONSUMER_WORK_SERVICE_THREAD_POOL_SIZE);
     }
 
     private void setUri() throws URISyntaxException, NoSuchAlgorithmException, KeyManagementException {
@@ -157,29 +207,64 @@ public class MulticastSet {
         return uri;
     }
 
+    public void setThreadingHandler(ThreadingHandler threadingHandler) {
+        this.threadingHandler = threadingHandler;
+    }
+
     /**
      * Abstraction for thread management.
      * Exists to ease testing.
      */
-    interface ThreadHandler {
+    interface ThreadingHandler {
 
-        void start(Thread thread);
+        ExecutorService executorService(String name, int nbThreads);
 
-        void waitForCompletion(Thread thread) throws InterruptedException;
+        ScheduledExecutorService scheduledExecutorService(String name, int nbThreads);
+
+        void shutdown();
 
     }
 
-    static class DefaultThreadHandler implements ThreadHandler {
+    static class DefaultThreadingHandler implements ThreadingHandler {
+
+        private final Collection<ExecutorService> executorServices = new ArrayList<>();
 
         @Override
-        public void start(Thread thread) {
-            thread.start();
+        public ExecutorService executorService(String name, int nbThreads) {
+            if (nbThreads <= 0) {
+                return create(() -> new ThreadPoolExecutor(0, 1,
+                    60L, TimeUnit.SECONDS,
+                    new SynchronousQueue<>(),
+                    new NamedThreadFactory(name)));
+            } else {
+                return create(() -> Executors.newFixedThreadPool(nbThreads, new NamedThreadFactory(name)));
+            }
         }
 
         @Override
-        public void waitForCompletion(Thread thread) throws InterruptedException {
-            thread.join();
+        public ScheduledExecutorService scheduledExecutorService(String name, int nbThreads) {
+            return (ScheduledExecutorService) create(() -> Executors.newScheduledThreadPool(nbThreads, new NamedThreadFactory(name)));
         }
+
+        private ExecutorService create(Supplier<ExecutorService> s) {
+            ExecutorService executorService = s.get();
+            this.executorServices.add(executorService);
+            return executorService;
+        }
+
+        @Override
+        public void shutdown() {
+            for (ExecutorService executorService : executorServices) {
+                executorService.shutdown();
+            }
+        }
+    }
+
+    private static class AgentState {
+
+        private Runnable runnable;
+
+        private Future<?> task;
 
     }
 

--- a/src/main/java/com/rabbitmq/perf/NamedThreadFactory.java
+++ b/src/main/java/com/rabbitmq/perf/NamedThreadFactory.java
@@ -1,0 +1,49 @@
+// Copyright (c) 2018-Present Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.perf;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A {@link ThreadFactory} that names threads with a prefix and a sequence number.
+ * @since 2.1.0
+ */
+public class NamedThreadFactory implements ThreadFactory {
+
+    private final ThreadFactory backingThreaFactory;
+
+    private final String prefix;
+
+    private final AtomicLong count = new AtomicLong(0);
+
+    public NamedThreadFactory(String prefix) {
+        this(Executors.defaultThreadFactory(), prefix);
+    }
+
+    public NamedThreadFactory(ThreadFactory backingThreaFactory, String prefix) {
+        this.backingThreaFactory = backingThreaFactory;
+        this.prefix = prefix;
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        Thread thread = this.backingThreaFactory.newThread(r);
+        thread.setName(prefix + count.getAndIncrement());
+        return thread;
+    }
+}

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -105,6 +105,7 @@ public class PerfTest {
             boolean useMillis        = cmd.hasOption("ms");
             String queueArgs         = strArg(cmd, "qa", null);
             int consumerLatencyInMicroseconds = intArg(cmd, 'L', 0);
+            int heartbeatSenderThreads = intArg(cmd, "hst", -1);
 
             String uri               = strArg(cmd, 'h', "amqp://localhost");
             String urisParameter     = strArg(cmd, 'H', null);
@@ -206,6 +207,7 @@ public class PerfTest {
             p.setQueuePattern(queuePattern);
             p.setQueueSequenceFrom(from);
             p.setQueueSequenceTo(to);
+            p.setHeartbeatSenderThreads(heartbeatSenderThreads);
 
             MulticastSet set = new MulticastSet(stats, factory, p, testID, uris);
             set.run(true);
@@ -311,6 +313,7 @@ public class PerfTest {
         options.addOption(new Option("qp", "queue-pattern",         true, "queue name pattern for creating queues in sequence"));
         options.addOption(new Option("F", "queue-pattern-from",     true, "sequence start for queue pattern (included)"));
         options.addOption(new Option("T", "queue-pattern-to",       true, "sequence end for queue pattern (included)"));
+        options.addOption(new Option("hst", "heartbeat-sender-threads",       true, "number of threads for producers and consumers heartbeat senders"));
         return options;
     }
 

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -49,7 +49,6 @@ public class PerfTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(PerfTest.class);
 
     public static void main(String [] args, PerfTestOptions perfTestOptions) {
-        args = "-r 1 -x 10 -y 10".split(" ");
         SystemExiter systemExiter = perfTestOptions.systemExiter;
         Options options = getOptions();
         CommandLineParser parser = new GnuParser();

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -49,6 +49,7 @@ public class PerfTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(PerfTest.class);
 
     public static void main(String [] args, PerfTestOptions perfTestOptions) {
+        args = "-r 1 -x 10 -y 10".split(" ");
         SystemExiter systemExiter = perfTestOptions.systemExiter;
         Options options = getOptions();
         CommandLineParser parser = new GnuParser();

--- a/src/main/java/com/rabbitmq/perf/SimpleScenario.java
+++ b/src/main/java/com/rabbitmq/perf/SimpleScenario.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 public class SimpleScenario implements Scenario {
@@ -41,7 +42,8 @@ public class SimpleScenario implements Scenario {
         this.interval = interval;
     }
 
-    public void run() throws IOException, InterruptedException, TimeoutException, NoSuchAlgorithmException, KeyManagementException, URISyntaxException {
+    public void run()
+        throws IOException, InterruptedException, TimeoutException, NoSuchAlgorithmException, KeyManagementException, URISyntaxException, ExecutionException {
         this.stats = new SimpleScenarioStats(interval);
         for (MulticastParams p : params) {
             MulticastSet set = new MulticastSet(stats, factory, p, null);

--- a/src/test/java/com/rabbitmq/perf/MulticastSetTest.java
+++ b/src/test/java/com/rabbitmq/perf/MulticastSetTest.java
@@ -1,0 +1,56 @@
+// Copyright (c) 2018-Present Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.perf;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.rabbitmq.perf.MulticastSet.nbThreadsForConsumer;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ *
+ */
+public class MulticastSetTest {
+
+    MulticastParams params;
+
+    @BeforeEach
+    public void init() {
+        params = new MulticastParams();
+    }
+
+    @Test
+    public void nbThreadsForConsumerShouldBeEqualsToChannelCount() {
+        params.setConsumerChannelCount(1);
+        assertThat(nbThreadsForConsumer(params), is(1));
+        params.setConsumerChannelCount(2);
+        assertThat(nbThreadsForConsumer(params), is(2));
+    }
+
+    @Test
+    public void nbThreadsForConsumerShouldBeEqualsToDefaultConsumerWorkServiceThreadCount() {
+        params.setConsumerChannelCount(MulticastSet.DEFAULT_CONSUMER_WORK_SERVICE_THREAD_POOL_SIZE);
+        assertThat(nbThreadsForConsumer(params), is(MulticastSet.DEFAULT_CONSUMER_WORK_SERVICE_THREAD_POOL_SIZE));
+    }
+
+    @Test
+    public void nbThreadsForConsumerShouldNotBeMoreThanDefaultConsumerWorkServiceThreadCount() {
+        params.setConsumerChannelCount(MulticastSet.DEFAULT_CONSUMER_WORK_SERVICE_THREAD_POOL_SIZE * 2);
+        assertThat(nbThreadsForConsumer(params), is(MulticastSet.DEFAULT_CONSUMER_WORK_SERVICE_THREAD_POOL_SIZE));
+    }
+}


### PR DESCRIPTION
This commit rationalizes the number of threads used by
a PerfTest instance. This should result in much fewer
threads used for common scenarios and should help to
run tests that simulate high load (many producers and/or consumers).

Previous behavior:

* One thread to run each consumer and producer
* Number of cores * 2 threads created for each consumer and producer in the consumer dispatch pool (even though producers won't really use them!)
* One thread to send heartbeats for each consumer and producer

New behavior:

* Threading is now handle with ExecutorServices
* PerfTest threads are prefixed with "perf-test-"
* There's only one thread to start all the consumers, as
the PerfTest Consumer just register a Java Client Consumer
and wait.
* Each consumer connection now uses an appropriate number
of threads for its Java Client consumers, e.g. 1 thread for each
channel, and no more than nb cores * 2 if number of channels
is > nb cores * 2. This should behave as previously, but
with fewer threads if the number of channels is small.
* The --heartbeat-sender-threads parameter allows to specify
the number of threads for all the producers and the consumers.
The default is nb producers + nb consumers (to stick to default
behavior), and it can be lowered down significantly manually, as
a few threads should be enough, especially for a performance tool.
* Producers don't allocate any threads for their consumers, as they
don't have any.

[#154174064]

Fixes #70