### PR TITLE
Add support for exclusive queues with -E flag

### DIFF
--- a/src/main/java/com/rabbitmq/perf/MulticastSet.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastSet.java
@@ -241,7 +241,7 @@ public class MulticastSet {
         @Override
         public void shutdown() {
             for (ExecutorService executorService : executorServices) {
-                executorService.shutdown();
+                executorService.shutdownNow();
             }
         }
     }

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -108,6 +108,7 @@ public class PerfTest {
             int heartbeatSenderThreads = intArg(cmd, "hst", -1);
             String messageProperties = strArg(cmd, "mp", null);
             int routingKeyCacheSize  = intArg(cmd, "rkcs", 0);
+            boolean exclusive = cmd.hasOption('E');
 
             String uri               = strArg(cmd, 'h', "amqp://localhost");
             String urisParameter     = strArg(cmd, 'H', null);
@@ -212,6 +213,7 @@ public class PerfTest {
             p.setHeartbeatSenderThreads(heartbeatSenderThreads);
             p.setMessageProperties(convertKeyValuePairs(messageProperties));
             p.setRoutingKeyCacheSize(routingKeyCacheSize);
+            p.setExclusive(exclusive);
 
             MulticastSet.CompletionHandler completionHandler = getCompletionHandler(p);
 
@@ -345,6 +347,7 @@ public class PerfTest {
         options.addOption(new Option("mp", "message-properties",    true, "message properties as key/pair values, separated by commas, "
                                                                                                     + "e.g. priority=5"));
         options.addOption(new Option("rkcs", "routing-key-cache-size",true, "size of the random routing keys cache. See --random-routing-key."));
+        options.addOption(new Option("E", "exclusive",     false,"declare random queues"));
         return options;
     }
 

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -347,7 +347,8 @@ public class PerfTest {
         options.addOption(new Option("mp", "message-properties",    true, "message properties as key/pair values, separated by commas, "
                                                                                                     + "e.g. priority=5"));
         options.addOption(new Option("rkcs", "routing-key-cache-size",true, "size of the random routing keys cache. See --random-routing-key."));
-        options.addOption(new Option("E", "exclusive",     false,"declare random queues"));
+        options.addOption(new Option("E", "exclusive",                false, "use server-named exclusive queues. "
+                                                                                        + "Such queues can only be used by their declaring connection!"));
         return options;
     }
 

--- a/src/test/java/com/rabbitmq/perf/MessageCountTimeLimitTest.java
+++ b/src/test/java/com/rabbitmq/perf/MessageCountTimeLimitTest.java
@@ -81,6 +81,24 @@ public class MessageCountTimeLimitTest {
 
     volatile long testDurationInMs;
 
+    static Stream<Arguments> producerCountArguments() {
+        return Stream.of(
+            Arguments.of(1, 1),
+            Arguments.of(10, 1),
+            Arguments.of(1, 10),
+            Arguments.of(2, 5)
+        );
+    }
+
+    static Stream<Arguments> consumerCountArguments() {
+        return Stream.of(
+            Arguments.of(1, 1),
+            Arguments.of(10, 1),
+            Arguments.of(1, 10),
+            Arguments.of(2, 5)
+        );
+    }
+
     @BeforeEach
     public void init() throws Exception {
         initMocks(this);
@@ -137,15 +155,6 @@ public class MessageCountTimeLimitTest {
         assertThat(testDurationInMs, greaterThan(5000L));
     }
 
-    static Stream<Arguments> producerCountArguments() {
-        return Stream.of(
-            Arguments.of(1, 1),
-            Arguments.of(10, 1),
-            Arguments.of(1, 10),
-            Arguments.of(2, 5)
-        );
-    }
-
     // -y 1 --pmessages 10 -x n -X m
     @ParameterizedTest
     @MethodSource("producerCountArguments")
@@ -176,15 +185,6 @@ public class MessageCountTimeLimitTest {
                 anyBoolean(), eq(false),
                 any(), any(byte[].class)
             );
-    }
-
-    static Stream<Arguments> consumerCountArguments() {
-        return Stream.of(
-            Arguments.of(1, 1),
-            Arguments.of(10, 1),
-            Arguments.of(1, 10),
-            Arguments.of(2, 5)
-        );
     }
 
     // --cmessages 10 -y n -Y m


### PR DESCRIPTION
This is especially useful with the queue sequence options, but
only if the number of queues and of consumers are the same. If more
queues than consumers are specified, extra queues won't be created.
If more consumers than queues are specified, extra consumers won't
be able to consume from queues, as they don't use the same connection.

[#155934728]
Fixes #76