### PR TITLE
Support environment variables as arguments

### DIFF
--- a/src/main/java/com/rabbitmq/perf/CommandLineProxy.java
+++ b/src/main/java/com/rabbitmq/perf/CommandLineProxy.java
@@ -1,0 +1,96 @@
+// Copyright (c) 2018-Present Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.perf;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static java.lang.String.valueOf;
+
+/**
+ * A proxy to add behavior around a {@link CommandLine}.
+ * It implements only the few methods used in {@link PerfTest}.
+ * This class has been introduced to easily make environment
+ * variables override or directly set arguments.
+ *
+ * {@link CommandLine} doesn't implement any interface nor
+ * can be subclassed, that's why this proxy trick is used.
+ */
+public class CommandLineProxy {
+
+    private final CommandLine delegate;
+
+    private final Function<String, String> argumentLookup;
+
+    public CommandLineProxy(final Options options, CommandLine delegate, Function<String, String> argumentLookup) {
+        this.delegate = delegate;
+        Function<String, String> optionToLongOption = option -> {
+            for (Object optObj : options.getOptions()) {
+                Option opt = (Option) optObj;
+                if (opt.getOpt().equals(option)) {
+                    return opt.getLongOpt();
+                }
+            }
+            return null;
+        };
+        this.argumentLookup = optionToLongOption
+            .andThen(longOption -> longOption == null ? null : argumentLookup.apply(longOption));
+    }
+
+    public boolean hasOption(char opt) {
+        return override(valueOf(opt), () -> delegate.hasOption(opt), Boolean.class);
+    }
+
+    public boolean hasOption(String opt) {
+        return override(opt, () -> delegate.hasOption(opt), Boolean.class);
+    }
+
+    public String getOptionValue(char opt, String def) {
+        return override(valueOf(opt), () -> delegate.getOptionValue(opt, def), String.class);
+    }
+
+    public String getOptionValue(String opt, String def) {
+        return override(opt, () -> delegate.getOptionValue(opt, def), String.class);
+    }
+
+    public String[] getOptionValues(char opt) {
+        return override(valueOf(opt), () -> delegate.getOptionValues(opt), String[].class);
+    }
+
+    public String getOptionValue(char opt) {
+        return override(valueOf(opt), () -> delegate.getOptionValue(opt), String.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T override(String opt, Supplier<T> argumentValue, Class<T> type) {
+        String value = argumentLookup.apply(opt);
+        if (value == null) {
+            return argumentValue.get();
+        } else {
+            if (Boolean.class.equals(type)) {
+                return (T) Boolean.valueOf(value);
+            } else if (String[].class.equals(type)) {
+                return (T) value.split(",");
+            } else {
+                return (T) value;
+            }
+        }
+    }
+}

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -20,16 +20,15 @@ import java.nio.charset.Charset;
 import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.Executors;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import com.rabbitmq.client.impl.ClientVersion;
 import com.rabbitmq.client.impl.nio.NioParams;
@@ -50,6 +49,7 @@ import javax.net.ssl.SSLContext;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
 public class PerfTest {
 
@@ -60,7 +60,8 @@ public class PerfTest {
         Options options = getOptions();
         CommandLineParser parser = new GnuParser();
         try {
-            CommandLine cmd = parser.parse(options, args);
+            CommandLine rawCmd = parser.parse(options, args);
+            CommandLineProxy cmd = new CommandLineProxy(options, rawCmd, perfTestOptions.argumentLookup);
 
             if (cmd.hasOption('?')) {
                 usage(options);
@@ -79,8 +80,8 @@ public class PerfTest {
             String exchangeName      = getExchangeName(cmd, exchangeType);
             String queueNames        = strArg(cmd, 'u', null);
             String routingKey        = strArg(cmd, 'k', null);
-            boolean randomRoutingKey = cmd.hasOption('K');
-            boolean skipBindingQueues= cmd.hasOption("sb");
+            boolean randomRoutingKey = hasOption(cmd, "K");
+            boolean skipBindingQueues= hasOption(cmd,"sb");
             int samplingInterval     = intArg(cmd, 'i', 1);
             float producerRateLimit  = floatArg(cmd, 'r', 0.0f);
             float consumerRateLimit  = floatArg(cmd, 'R', 0.0f);
@@ -92,12 +93,12 @@ public class PerfTest {
             int consumerTxSize       = intArg(cmd, 'n', 0);
             long confirm             = intArg(cmd, 'c', -1);
             int confirmTimeout       = intArg(cmd, "ct", 30);
-            boolean autoAck          = cmd.hasOption('a');
+            boolean autoAck          = hasOption(cmd,"a");
             int multiAckEvery        = intArg(cmd, 'A', 0);
             int channelPrefetch      = intArg(cmd, 'Q', 0);
             int consumerPrefetch     = intArg(cmd, 'q', 0);
             int minMsgSize           = intArg(cmd, 's', 0);
-            boolean slowStart        = cmd.hasOption('S');
+            boolean slowStart        = hasOption(cmd, "S");
             int timeLimit            = intArg(cmd, 'z', 0);
             int producerMsgCount     = intArg(cmd, 'C', 0);
             int consumerMsgCount     = intArg(cmd, 'D', 0);
@@ -106,17 +107,17 @@ public class PerfTest {
             int heartbeat            = intArg(cmd, 'b', 0);
             String bodyFiles         = strArg(cmd, 'B', null);
             String bodyContentType   = strArg(cmd, 'T', null);
-            boolean predeclared      = cmd.hasOption('p');
-            boolean legacyMetrics    = cmd.hasOption('l');
+            boolean predeclared      = hasOption(cmd, "p");
+            boolean legacyMetrics    = hasOption(cmd, "l");
             boolean autoDelete       = boolArg(cmd, "ad", true);
-            boolean useMillis        = cmd.hasOption("ms");
-            boolean saslExternal     = cmd.hasOption("se");
+            boolean useMillis        = hasOption(cmd,"ms");
+            boolean saslExternal     = hasOption(cmd, "se");
             String queueArgs         = strArg(cmd, "qa", null);
             int consumerLatencyInMicroseconds = intArg(cmd, 'L', 0);
             int heartbeatSenderThreads = intArg(cmd, "hst", -1);
             String messageProperties = strArg(cmd, "mp", null);
             int routingKeyCacheSize  = intArg(cmd, "rkcs", 0);
-            boolean exclusive = cmd.hasOption('E');
+            boolean exclusive = hasOption(cmd, "E");
             int publishingIntervalInSeconds = intArg(cmd, "P", -1);
             int producerRandomStartDelayInSeconds = intArg(cmd, "prsd", -1);
             int producerSchedulingThreads = intArg(cmd, "pst", -1);
@@ -145,7 +146,7 @@ public class PerfTest {
                 }
                 uris = asList(urisArray);
             } else {
-                uris = Collections.singletonList(uri);
+                uris = singletonList(uri);
             }
 
             //setup
@@ -254,7 +255,7 @@ public class PerfTest {
         }
     }
 
-    private static ConnectionFactory configureNioIfRequested(CommandLine cmd, ConnectionFactory factory) {
+    private static ConnectionFactory configureNioIfRequested(CommandLineProxy cmd, ConnectionFactory factory) {
         int nbThreads = intArg(cmd, "niot", -1);
         int executorSize = intArg(cmd, "niotp", -1);
         if (nbThreads > 0 || executorSize > 0) {
@@ -313,9 +314,9 @@ public class PerfTest {
         main(args, new PerfTestOptions().setSystemExiter(new JvmSystemExiter()).setSkipSslContextConfiguration(false));
     }
 
-    private static SSLContext getSslContextIfNecessary(CommandLine cmd, Properties systemProperties) throws NoSuchAlgorithmException {
+    private static SSLContext getSslContextIfNecessary(CommandLineProxy cmd, Properties systemProperties) throws NoSuchAlgorithmException {
         SSLContext sslContext = null;
-        if (cmd.hasOption("useDefaultSslContext")) {
+        if (hasOption(cmd, "udsc") || hasOption(cmd,"useDefaultSslContext")) {
             LOGGER.info("Using default SSL context as per command line option");
             sslContext = SSLContext.getDefault();
         }
@@ -338,7 +339,7 @@ public class PerfTest {
         formatter.printHelp("<program>", options);
     }
 
-    private static Options getOptions() {
+    static Options getOptions() {
         Options options = new Options();
         options.addOption(new Option("?", "help",                   false,"show usage"));
         options.addOption(new Option("d", "id",                     true, "test ID"));
@@ -417,36 +418,40 @@ public class PerfTest {
         return options;
     }
 
-    private static String strArg(CommandLine cmd, char opt, String def) {
+    private static String strArg(CommandLineProxy cmd, char opt, String def) {
         return cmd.getOptionValue(opt, def);
     }
 
-    private static String strArg(CommandLine cmd, String opt, String def) {
+    private static String strArg(CommandLineProxy cmd, String opt, String def) {
         return cmd.getOptionValue(opt, def);
     }
 
-    private static int intArg(CommandLine cmd, char opt, int def) {
+    private static int intArg(CommandLineProxy cmd, char opt, int def) {
         return Integer.parseInt(cmd.getOptionValue(opt, Integer.toString(def)));
     }
 
-    private static int intArg(CommandLine cmd, String opt, int def) {
+    private static int intArg(CommandLineProxy cmd, String opt, int def) {
         return Integer.parseInt(cmd.getOptionValue(opt, Integer.toString(def)));
     }
 
-    private static float floatArg(CommandLine cmd, char opt, float def) {
+    private static float floatArg(CommandLineProxy cmd, char opt, float def) {
         return Float.parseFloat(cmd.getOptionValue(opt, Float.toString(def)));
     }
 
-    private static boolean boolArg(CommandLine cmd, String opt, boolean def) {
+    private static boolean boolArg(CommandLineProxy cmd, String opt, boolean def) {
         return Boolean.parseBoolean(cmd.getOptionValue(opt, Boolean.toString(def)));
     }
 
-    private static List<?> lstArg(CommandLine cmd, char opt) {
+    private static List<?> lstArg(CommandLineProxy cmd, char opt) {
         String[] vals = cmd.getOptionValues(opt);
         if (vals == null) {
             vals = new String[] {};
         }
         return asList(vals);
+    }
+
+    private static boolean hasOption(CommandLineProxy cmd, String opt) {
+        return cmd.hasOption(opt);
     }
 
     private static Map<String, Object> convertKeyValuePairs(String arg) {
@@ -465,7 +470,7 @@ public class PerfTest {
         return properties;
     }
 
-    private static String getExchangeName(CommandLine cmd, String def) {
+    private static String getExchangeName(CommandLineProxy cmd, String def) {
         String exchangeName = null;
         if (cmd.hasOption('e')) {
             exchangeName = cmd.getOptionValue('e');
@@ -648,6 +653,10 @@ public class PerfTest {
 
         private boolean skipSslContextConfiguration = false;
 
+        private Function<String, String> argumentLookup = LONG_OPTION_TO_ENVIRONMENT_VARIABLE
+            .andThen(ENVIRONMENT_VARIABLE_PREFIX)
+            .andThen(ENVIRONMENT_VARIABLE_LOOKUP);
+
         public PerfTestOptions setSystemExiter(SystemExiter systemExiter) {
             this.systemExiter = systemExiter;
             return this;
@@ -655,6 +664,11 @@ public class PerfTest {
 
         public PerfTestOptions setSkipSslContextConfiguration(boolean skipSslContextConfiguration) {
             this.skipSslContextConfiguration = skipSslContextConfiguration;
+            return this;
+        }
+
+        public PerfTestOptions setArgumentLookup(Function<String, String> argumentLookup) {
+            this.argumentLookup = argumentLookup;
             return this;
         }
     }
@@ -681,5 +695,22 @@ public class PerfTest {
         }
 
     }
+
+    static Function<String, String> LONG_OPTION_TO_ENVIRONMENT_VARIABLE = option ->
+        option.replace('-', '_').toUpperCase(Locale.ENGLISH);
+
+    static Function<String, String> ENVIRONMENT_VARIABLE_PREFIX = name -> {
+        String prefix = System.getenv("RABBITMQ_PERF_TEST_ENV_PREFIX");
+        if (prefix == null || prefix.trim().isEmpty()) {
+            return name;
+        }
+        if (prefix.endsWith("_")) {
+            return prefix + name;
+        } else {
+            return prefix + "_" + name;
+        }
+    };
+
+    static Function<String, String> ENVIRONMENT_VARIABLE_LOOKUP = name -> System.getenv(name);
 
 }

--- a/src/test/java/com/rabbitmq/perf/CommandLineProxyTest.java
+++ b/src/test/java/com/rabbitmq/perf/CommandLineProxyTest.java
@@ -1,0 +1,149 @@
+// Copyright (c) 2018-Present Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.perf;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CommandLineProxyTest {
+
+    @Test
+    public void delegateWorksOk() throws ParseException {
+        Map<String, String> env = new HashMap<>();
+        String line = "-r 100 -f persistent -f mandatory -p";
+        CommandLineProxy cmd = getCommandLineProxy(env, line);
+
+        assertEquals(
+            "100",
+            cmd.getOptionValue('r')
+        );
+        assertEquals(
+            "100",
+            cmd.getOptionValue("r", "")
+        );
+        assertEquals(
+            "100",
+            cmd.getOptionValue('r', "")
+        );
+        assertEquals(
+            "default",
+            cmd.getOptionValue("u", "default")
+        );
+        assertEquals(
+            "default",
+            cmd.getOptionValue('u', "default")
+        );
+        assertArrayEquals(
+            new String[] { "persistent", "mandatory" },
+            cmd.getOptionValues('f')
+        );
+        assertTrue(
+            cmd.hasOption("p")
+        );
+        assertTrue(
+            cmd.hasOption('p')
+        );
+    }
+
+    @Test
+    public void envVariablesOverrideAndAreUsed() throws ParseException {
+        Map<String, String> env = new HashMap<>();
+        env.put("RATE", "200");
+        env.put("PRODUCER_CHANNEL_COUNT", "10");
+
+        String line = "-r 100";
+        CommandLineProxy cmd = getCommandLineProxy(env, line);
+
+        assertEquals(
+            "200",
+            cmd.getOptionValue('r')
+        );
+        assertEquals(
+            "10",
+            cmd.getOptionValue('X')
+        );
+    }
+
+    @Test
+    public void envVariablesSupportTypeString() throws ParseException {
+        Map<String, String> env = new HashMap<>();
+        env.put("RATE", "200");
+        CommandLineProxy cmd = getCommandLineProxy(env, "");
+        assertEquals(
+            "200",
+            cmd.getOptionValue('r')
+        );
+    }
+
+    @Test
+    public void envVariablesSupportTypeStringArray() throws ParseException {
+        Map<String, String> env = new HashMap<>();
+        env.put("FLAG", "mandatory,persistent");
+        CommandLineProxy cmd = getCommandLineProxy(env, "");
+        assertArrayEquals(
+            new String[] { "mandatory", "persistent" },
+            cmd.getOptionValues('f')
+        );
+    }
+
+    @Test
+    public void envVariablesSupportTypeBooleanFalse() throws ParseException {
+        Map<String, String> env = new HashMap<>();
+        env.put("AUTO_DELETE", "FALSE");
+        CommandLineProxy cmd = getCommandLineProxy(env, "");
+        assertFalse(
+            cmd.hasOption("ad")
+        );
+    }
+
+    @Test
+    public void envVariablesSupportTypeBooleanTrue() throws ParseException {
+        Map<String, String> env = new HashMap<>();
+        env.put("AUTO_DELETE", "TRUE");
+        CommandLineProxy cmd = getCommandLineProxy(env, "");
+        assertTrue(
+            cmd.hasOption("ad")
+        );
+    }
+
+    private CommandLineProxy getCommandLineProxy(Map<String, String> env, String line) throws ParseException {
+        Function<String, String> envLookup = variable -> env.get(variable);
+        Options options = PerfTest.getOptions();
+        CommandLineParser parser = new GnuParser();
+        CommandLine rawCmd = parser.parse(
+            options,
+            line.split(" ")
+        );
+        return new CommandLineProxy(
+            options,
+            rawCmd,
+            PerfTest.LONG_OPTION_TO_ENVIRONMENT_VARIABLE.andThen(envLookup)
+        );
+    }
+}

--- a/src/test/java/com/rabbitmq/perf/PerfTestTest.java
+++ b/src/test/java/com/rabbitmq/perf/PerfTestTest.java
@@ -18,6 +18,7 @@ package com.rabbitmq.perf;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -51,6 +52,21 @@ public class PerfTestTest {
                     fail(message + " (test shouldn't fail)");
                 }
             }
+        }
+    }
+
+    @Test public void longOptionToEnvironmentVariable() {
+        String [] [] parameters = {
+            {"queue", "QUEUE"},
+            {"routing-key", "ROUTING_KEY"},
+            {"random-routing-key", "RANDOM_ROUTING_KEY"},
+            {"skip-binding-queues", "SKIP_BINDING_QUEUES"},
+        };
+        for (String[] parameter : parameters) {
+            assertEquals(
+                parameter[1],
+                PerfTest.LONG_OPTION_TO_ENVIRONMENT_VARIABLE.apply(parameter[0])
+            );
         }
     }
 }


### PR DESCRIPTION
This commit allows to use environment variables to configure PerfTest.
Environment variables are prioritary over command line arguments. The
name of the environment variables is a snake case version of the long
command line argument name, e.g. --skip-binding-queues becomes
SKIP_BINDING_QUEUES. A prefix can be used by setting the
RABBITMQ_PERF_TEST_ENV_PREFIX environment variable.

[#157994032]

Fixes #97