### PR TITLE
Shutdown cleanly after Ctrl-C

### DIFF
--- a/src/main/java/com/rabbitmq/perf/RelaxedExceptionHandler.java
+++ b/src/main/java/com/rabbitmq/perf/RelaxedExceptionHandler.java
@@ -1,0 +1,56 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.perf;
+
+import com.rabbitmq.client.impl.DefaultExceptionHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Relaxed version of the {@link DefaultExceptionHandler} that logs
+ * network exceptions as info instead of warn.
+ * <p>
+ * Connections opened by PerfTest can be blocked, especially producer
+ * connections. On shutdown, they may take some time to close, so PerfTest
+ * closes the connection with a timeout. This can result in noisy logs,
+ * which are not useful here, so this exception handler is a bit more
+ * relaxed for those logs.
+ *
+ * @since 2.4.1
+ */
+public class RelaxedExceptionHandler extends DefaultExceptionHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RelaxedExceptionHandler.class);
+
+    private static boolean isSocketClosedOrConnectionReset(Throwable e) {
+        return e instanceof IOException &&
+                ("Connection reset".equals(e.getMessage()) || "Socket closed".equals(e.getMessage()) ||
+                        "Connection reset by peer".equals(e.getMessage())
+                );
+    }
+
+    @Override
+    protected void log(String message, Throwable e) {
+        if (isSocketClosedOrConnectionReset(e)) {
+            // we don't want to get too dramatic about those
+            LOGGER.info("{} (Exception message: {})", message, e.getMessage());
+        } else {
+            LOGGER.error(message, e);
+        }
+    }
+}

--- a/src/main/java/com/rabbitmq/perf/ShutdownService.java
+++ b/src/main/java/com/rabbitmq/perf/ShutdownService.java
@@ -1,0 +1,82 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.perf;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Helper to register callbacks and call them in reverse order.
+ * Registered callbacks are made automatically idempotent.
+ * <p>
+ * This class can be used to register closing callbacks, call them
+ * individually, and/or call all of them (in LIFO order) with
+ * the {@link #close()} method.
+ *
+ * @since 2.4.1
+ */
+public class ShutdownService implements AutoCloseable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ShutdownService.class);
+
+    private final List<AutoCloseable> closeables = Collections.synchronizedList(new ArrayList<>());
+
+    /**
+     * Wrap and register the callback into an idempotent {@link AutoCloseable}.
+     *
+     * @param closeCallback
+     * @return the callback as an idempotent {@link AutoCloseable}
+     */
+    AutoCloseable wrap(CloseCallback closeCallback) {
+        AtomicBoolean closingOrAlreadyClosed = new AtomicBoolean(false);
+        AutoCloseable idempotentCloseCallback = () -> {
+            if (closingOrAlreadyClosed.compareAndSet(false, true)) {
+                closeCallback.run();
+            }
+        };
+        closeables.add(idempotentCloseCallback);
+        return idempotentCloseCallback;
+    }
+
+    /**
+     * Close all the registered callbacks, in the reverse order of registration.
+     */
+    @Override
+    public void close() {
+        if (closeables.size() > 0) {
+            for (int i = closeables.size() - 1; i >= 0; i--) {
+                try {
+                    closeables.get(i).close();
+                } catch (Exception e) {
+                    LOGGER.warn("Could not properly closed {}", closeables.get(i), e);
+                }
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface CloseCallback {
+
+        void run() throws Exception;
+
+    }
+
+}

--- a/src/test/java/com/rabbitmq/perf/ShutdownServiceTest.java
+++ b/src/test/java/com/rabbitmq/perf/ShutdownServiceTest.java
@@ -1,0 +1,48 @@
+// Copyright (c) 2018 Pivotal Software, Inc.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.perf;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.iterableWithSize;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
+
+public class ShutdownServiceTest {
+
+    ShutdownService service = new ShutdownService();
+
+    @Test
+    public void closeIsLifoAndIdempotent() throws Exception {
+        List<AutoCloseable> closeCallbacks = new ArrayList<>();
+        List<String> markers = new ArrayList<>();
+        closeCallbacks.add(service.wrap(() -> markers.add("1")));
+        closeCallbacks.add(service.wrap(() -> markers.add("2")));
+        closeCallbacks.add(service.wrap(() -> markers.add("3")));
+        service.close();
+        assertThat(markers, iterableWithSize(closeCallbacks.size()));
+        assertThat(markers, contains("3", "2", "1"));
+        for (AutoCloseable closeCallback : closeCallbacks) {
+            closeCallback.close();
+        }
+        assertThat(markers, iterableWithSize(closeCallbacks.size()));
+        assertThat(markers, contains("3", "2", "1"));
+    }
+
+}

--- a/src/test/java/com/rabbitmq/perf/TopologyTest.java
+++ b/src/test/java/com/rabbitmq/perf/TopologyTest.java
@@ -392,7 +392,10 @@ public class TopologyTest {
                     // they can be un-used because some connections are re-used when there are more
                     // consumers than queues and queues are exclusive
                     if (args != null && args.length == 3) {
-                        unusedConnections.incrementAndGet();
+                        String reason = args[1].toString();
+                        if ("Connection not used".equals(reason)) {
+                            unusedConnections.incrementAndGet();
+                        }
                     }
                     return null;
                 })


### PR DESCRIPTION
This commit makes PerfTest shut down cleanly when the process is
Ctrl-C-ed. The closing tasks are accumulated in a shutdown service that
executes them whether the process exits normally or is Ctrl-C-ed.

Note this isn't bullet-proof: if some connections are throttled by the
broker because they publish too fast, closing them can easily time out,
so PerfTest may take some time to terminate and some "client
unexpectedly closed TCP connection" messages can still show up in the
broker.

For cases where PerfTest doesn't saturate the broker, it should
terminate fast and cleanly.

Fixes #126