### PR TITLE
Add shutdown timeout argument, defaults to 5 seconds

### DIFF
--- a/src/docs/asciidoc/usage.adoc
+++ b/src/docs/asciidoc/usage.adoc
@@ -144,3 +144,36 @@ messages from only one queue.
 Note it is possible to link:#customising-queues-and-messages[customise]
 the queue and to work against link:#working-with-many-queues[several queues] as well.
 
+== Stopping PerfTest
+
+There are 2 reasons for a PerfTest run to stop:
+
+ * one of the limits has been reached (time limit, producer or consumer message count)
+ * the process is stopped by the user, e.g. by using Ctrl-C in the terminal
+
+In both cases, PerfTest tries to exit as cleanly as possible, in a reasonable amount of time.
+Nevertheless, when PerfTest AMQP connections are throttled by the broker, because they're
+publishing too fast or because broker http://www.rabbitmq.com/alarms.html[alarms]
+have kicked in, it can take time to close them (several seconds or more for one connection).
+
+If closing connections in the gentle way takes too long (5 seconds by default), PerfTest
+will move on to the most important resources to free and terminates. This can result
+in `client unexpectedly closed TCP connection` messages in the broker logs. Note this
+means the AMQP connection hasn't been closed with the right sequence of AMQP frames,
+but the socket has been closed properly. There's no resource leakage here.
+
+The connection closing timeout can be set up with the `--shutdown-timeout` argument (or `-st`).
+The default timeout can be increased to let more time to close connections, e.g. the
+command below uses a shutdown timeout of 20 seconds:
+
+ bin/runjava com.rabbitmq.perf.PerfTest --shutdown-timeout 20
+
+The connection closing sequence can also be skipped by setting the timeout to 0 or any negative
+value:
+
+ bin/runjava com.rabbitmq.perf.PerfTest --shutdown-timeout -1
+
+With the previous command, PerfTest won't even try to close AMQP connections, it will exit
+as fast as possible, freeing only the most important resources. This is perfectly
+acceptable when performing runs on a test environment.
+

--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -92,6 +92,7 @@ public class MulticastParams {
     private int producerRandomStartDelayInSeconds;
     private int producerSchedulerThreadCount = -1;
     private int consumersThreadPools = -1;
+    private int shutdownTimeout = 5;
 
     public void setExchangeType(String exchangeType) {
         this.exchangeType = exchangeType;
@@ -234,6 +235,10 @@ public class MulticastParams {
         this.consumersThreadPools = consumersThreadPools;
     }
 
+    public void setShutdownTimeout(int shutdownTimeout) {
+        this.shutdownTimeout = shutdownTimeout;
+    }
+
     public int getConsumerCount() {
         return consumerCount;
     }
@@ -316,6 +321,10 @@ public class MulticastParams {
 
     public int getConsumersThreadPools() {
         return consumersThreadPools;
+    }
+
+    public int getShutdownTimeout() {
+        return shutdownTimeout;
     }
 
     public Producer createProducer(Connection connection, Stats stats, MulticastSet.CompletionHandler completionHandler) throws IOException {

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -135,6 +135,7 @@ public class PerfTest {
 
             boolean disableConnectionRecovery = hasOption(cmd, "dcr");
             int consumersThreadPools = intArg(cmd, "ctp", -1);
+            int shutdownTimeout = intArg(cmd, "st", 5);
 
             String uri               = strArg(cmd, 'h', "amqp://localhost");
             String urisParameter     = strArg(cmd, 'H', null);
@@ -260,6 +261,7 @@ public class PerfTest {
             p.setProducerRandomStartDelayInSeconds(producerRandomStartDelayInSeconds);
             p.setProducerSchedulerThreadCount(producerSchedulingThreads);
             p.setConsumersThreadPools(consumersThreadPools);
+            p.setShutdownTimeout(shutdownTimeout);
 
             MulticastSet.CompletionHandler completionHandler = getCompletionHandler(p);
 
@@ -496,6 +498,9 @@ public class PerfTest {
 
         options.addOption(new Option("ctp", "consumers-thread-pools",true, "number of thread pools to use for all consumers, "
             + "default is to use a thread pool for each consumer"));
+
+        options.addOption(new Option("st", "shutdown-timeout",true, "shutdown timeout, default is 5 seconds"));
+
         return options;
     }
 


### PR DESCRIPTION
The shutdown sequence (mainly connection closing) happens now in a
separate thread to be easily stopped. AMQP connections won't be closed
in case of timeout, but this avoids waiting for a long time when
publisher connections are all blocked.

[#162704749]

References #126