### PR TITLE
URL Cleanup

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.rabbitmq</groupId>
@@ -9,22 +9,22 @@
 
   <name>RabbitMQ Performance Testing Tool</name>
   <description>A Java-based performance testing tool for RabbitMQ.</description>
-  <url>http://www.rabbitmq.com</url>
+  <url>https://www.rabbitmq.com</url>
 
   <licenses>
     <license>
       <name>ASL 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
       <distribution>repo</distribution>
     </license>
     <license>
       <name>GPL v2</name>
-      <url>http://www.gnu.org/licenses/gpl-2.0.txt</url>
+      <url>https://www.gnu.org/licenses/gpl-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
     <license>
       <name>MPL 1.1</name>
-      <url>http://www.mozilla.org/MPL/MPL-1.1.txt</url>
+      <url>https://www.mozilla.org/MPL/MPL-1.1.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -47,7 +47,7 @@
 
   <organization>
     <name>Pivotal Software, Inc.</name>
-    <url>http://www.rabbitmq.com</url>
+    <url>https://www.rabbitmq.com</url>
   </organization>
 
   <properties>
@@ -344,7 +344,7 @@
           <backend>html5</backend>
           <sourceHighlighter>coderay</sourceHighlighter>
           <attributes>
-            <endpoint-url>http://example.org</endpoint-url>
+            <endpoint-url>https://example.org</endpoint-url>
             <sourcedir>${project.build.sourceDirectory}</sourcedir>
             <project-version>${project.version}</project-version>
             <imagesdir>./images</imagesdir>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://example.org with 1 occurrences migrated to:  
  https://example.org ([https](https://example.org) result 200).
* http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 with 2 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.html with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.html ([https](https://www.apache.org/licenses/LICENSE-2.0.html) result 200).
* http://www.gnu.org/licenses/gpl-2.0.txt with 1 occurrences migrated to:  
  https://www.gnu.org/licenses/gpl-2.0.txt ([https](https://www.gnu.org/licenses/gpl-2.0.txt) result 200).
* http://www.rabbitmq.com with 2 occurrences migrated to:  
  https://www.rabbitmq.com ([https](https://www.rabbitmq.com) result 200).
* http://www.mozilla.org/MPL/MPL-1.1.txt with 1 occurrences migrated to:  
  https://www.mozilla.org/MPL/MPL-1.1.txt ([https](https://www.mozilla.org/MPL/MPL-1.1.txt) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences