### PR TITLE
Build a Docker image with the local (dev) version of PerfTest

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+/.classpath
+/.idea
+/.project
+/.settings
+/target

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,64 @@
+FROM ubuntu:18.04 as builder
+
+RUN set -eux ; \
+    apt-get update ; \
+    apt-get install --yes --no-install-recommends \
+      ca-certificates \
+      make \
+      bash \
+      unzip \
+      wget
+
+# change the JAVA_URL variable below as well
+ENV JAVA_VERSION="11.0.2"
+# https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.2_9.tar.gz.sha256.txt
+ENV JAVA_SHA256="d02089d834f7702ac1a9776d8d0d13ee174d0656cf036c6b68b9ffb71a6f610e"
+ENV JAVA_URL="https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${JAVA_VERSION}%2B9/OpenJDK11U-jdk_x64_linux_hotspot_${JAVA_VERSION}_9.tar.gz"
+
+ENV JAVA_PATH="/jdk-${JAVA_VERSION}"
+ENV JAVA_HOME="${JAVA_PATH}"
+
+RUN set -eux ; \
+    wget --progress dot:giga --output-document "$JAVA_PATH.tar.gz" "$JAVA_URL" ; \
+    echo "$JAVA_SHA256 *$JAVA_PATH.tar.gz" | sha256sum --check --strict - ; \
+    mkdir -p "$JAVA_PATH" ; \
+    tar --extract --file "$JAVA_PATH.tar.gz" --directory "$JAVA_PATH" --strip-components 1 ; \
+    $JAVA_PATH/bin/jlink --compress=2 --output /jre --add-modules java.base,java.management,java.xml,java.naming,java.sql ; \
+    /jre/bin/java -version
+
+RUN mkdir -p /perf_test_dev
+WORKDIR /perf_test_dev
+# If we COPY ., the layer will be rebuilt whenever a file has changed in the project directory
+# We only care about the files used in the binary
+COPY .mvn .mvn/
+COPY bin bin/
+COPY html html/
+COPY images images/
+COPY scripts scripts/
+COPY src src/
+COPY Makefile mvnw mvnw.cmd pom.xml ./
+
+# Keep this as a self-contained step
+# If any of the following steps fail, the Maven deps will be cached
+RUN make binary
+
+RUN set -eux ; \
+    unzip target/rabbitmq-perf-test-*-SNAPSHOT-bin.zip ; \
+    mv rabbitmq-perf-test-*-SNAPSHOT /perf_test ; \
+    cd /perf_test ; \
+    bin/runjava com.rabbitmq.perf.PerfTest --help
+
+
+
+
+FROM ubuntu:18.04
+
+ENV JAVA_HOME=/jre
+COPY --from=builder /jre $JAVA_HOME/
+RUN ln -svT $JAVA_HOME/bin/java /usr/local/bin/java
+
+COPY --from=builder /perf_test /perf_test
+WORKDIR /perf_test
+RUN bin/runjava com.rabbitmq.perf.PerfTest --help
+
+ENTRYPOINT ["bin/runjava", "com.rabbitmq.perf.PerfTest"]

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ HARDWARE := $$(uname -m | tr '[:upper:]' '[:lower:]')
 
 GPG_KEYNAME := $$(awk -F'[<>]' '/<gpg.keyname>/ { print $$3 }' pom.xml)
 
+TODAY := $(shell date -u +'%Y.%m.%d')
+
 RELEASE_VERSION ?= 2.6.0
 PGP_KEYSERVER ?= pgpkeys.uk
 
@@ -25,6 +27,21 @@ binary: clean ## Build the binary distribution
 native-image: clean ## Build the native image
 	@mvnw -q package -DskipTests -P native-image -P '!java-packaging'
 	native-image -jar target/perf-test.jar -H:Features="com.rabbitmq.perf.NativeImageFeature"
+
+.PHONY: docker-image-dev
+docker-image-dev: ## Build Docker image with the local PerfTest version
+	@docker build \
+	  --file Dockerfile.dev \
+	  --tag pivotalrabbitmq/perf-test:dev-$(TODAY) \
+	  .
+
+.PHONY: test-docker-image-dev
+test-docker-image-dev: ## Test the Docker image with the local PerfTest version
+	@docker run -it --rm pivotalrabbitmq/perf-test:dev-$(TODAY) --version
+
+.PHONY: push-docker-image-dev
+push-docker-image-dev: ## Test the Docker image with the local PerfTest version
+	@docker push pivotalrabbitmq/perf-test:dev-$(TODAY)
 
 .PHONY: docker-image-alpine
 docker-image-alpine: ## Build Alpine-based Docker image


### PR DESCRIPTION
This is especially helpful for testing new PerfTest features in the
context of rabbitmq_prometheus, via https://github.com/rabbitmq/rabbitmq-prometheus/tree/master/docker

pivotalrabbitmq/perf-test:dev-2019.04.24 built & published to https://hub.docker.com/r/pivotalrabbitmq/perf-test/tags