### PR TITLE
Fixes type mismatch when using "confirm" parameter in json

### DIFF
--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -36,7 +36,7 @@ import static com.rabbitmq.perf.Recovery.setupRecoveryProcess;
 
 public class MulticastParams {
 
-    private long confirm = -1;
+    private int confirm = -1;
     private int confirmTimeout = 30;
     private int consumerCount = 1;
     private int producerCount = 1;
@@ -181,7 +181,7 @@ public class MulticastParams {
         this.consumerTxSize = consumerTxSize;
     }
 
-    public void setConfirm(long confirm) {
+    public void setConfirm(int confirm) {
         this.confirm = confirm;
     }
 

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -102,7 +102,7 @@ public class PerfTest {
             int consumerChannelCount = intArg(cmd, 'Y', 1);
             int producerTxSize       = intArg(cmd, 'm', 0);
             int consumerTxSize       = intArg(cmd, 'n', 0);
-            long confirm             = intArg(cmd, 'c', -1);
+            int confirm             = intArg(cmd, 'c', -1);
             int confirmTimeout       = intArg(cmd, "ct", 30);
             boolean autoAck          = hasOption(cmd,"a");
             int multiAckEvery        = intArg(cmd, 'A', 0);


### PR DESCRIPTION
When trying to convert the confirm parameter from a json number into a long type a type mismatch exception is thrown. This simply changes confirm into an int as I see no reason it should be a long.