### PR TITLE
Spread queue declaration across all nodes

### DIFF
--- a/src/main/java/com/rabbitmq/perf/Utils.java
+++ b/src/main/java/com/rabbitmq/perf/Utils.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-Present Pivotal Software, Inc.  All rights reserved.
+// Copyright (c) 2018-2019 Pivotal Software, Inc.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 1.1 ("MPL"), the GNU General Public License version 2
@@ -15,15 +15,26 @@
 
 package com.rabbitmq.perf;
 
+import com.rabbitmq.client.Address;
 import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
 
-public abstract class Utils {
+import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 
-    public static boolean isRecoverable(Connection connection) {
+abstract class Utils {
+
+    private static final ConnectionFactory CF = new ConnectionFactory();
+
+    static boolean isRecoverable(Connection connection) {
         return connection instanceof AutorecoveringConnection;
     }
 
-
+    static synchronized Address extract(String uri) throws NoSuchAlgorithmException, KeyManagementException, URISyntaxException {
+        CF.setUri(uri);
+        return new Address(CF.getHost(), CF.getPort());
+    }
 
 }

--- a/src/test/java/com/rabbitmq/perf/it/StartUpIT.java
+++ b/src/test/java/com/rabbitmq/perf/it/StartUpIT.java
@@ -20,10 +20,7 @@ import com.rabbitmq.perf.MulticastParams;
 import com.rabbitmq.perf.MulticastSet;
 import com.rabbitmq.perf.Stats;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Creates one configuration connection per node and uses them to declare
queues. It used to be only one configuration connection, so all queues would
end up on the same node.

Fixes #221