### PR TITLE
add jdk.crypto.cryptoki module to JRE run command

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -22,7 +22,7 @@ RUN set -eux; \
     echo "$JAVA_SHA256 *$JAVA_PATH.tar.gz" | sha256sum -c -; \
 	mkdir -p "$JAVA_PATH"; \
 	tar --extract --file "$JAVA_PATH.tar.gz" --directory "$JAVA_PATH" --strip-components 1; \
-	$JAVA_PATH/bin/jlink --compress=2 --output /jre --add-modules java.base,java.management,java.xml,java.naming,java.sql; \
+	$JAVA_PATH/bin/jlink --compress=2 --output /jre --add-modules java.base,java.management,java.xml,java.naming,java.sql,jdk.crypto.cryptoki; \
 	/jre/bin/java -version
 
 # pgpkeys.uk is quite reliable, but allow for substitutions locally

--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -22,7 +22,7 @@ RUN set -eux; \
 	echo "$JAVA_SHA256 *$JAVA_PATH.tar.gz" | sha256sum --check --strict -; \
 	mkdir -p "$JAVA_PATH"; \
 	tar --extract --file "$JAVA_PATH.tar.gz" --directory "$JAVA_PATH" --strip-components 1; \
-	$JAVA_PATH/bin/jlink --compress=2 --output /jre --add-modules java.base,java.management,java.xml,java.naming,java.sql; \
+	$JAVA_PATH/bin/jlink --compress=2 --output /jre --add-modules java.base,java.management,java.xml,java.naming,java.sql,jdk.crypto.cryptoki; \
 	/jre/bin/java -version
 
 # pgpkeys.uk is quite reliable, but allow for substitutions locally

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -21,7 +21,7 @@ RUN set -eux ; \
     echo "$JAVA_SHA256 *$JAVA_PATH.tar.gz" | sha256sum --check --strict - ; \
     mkdir -p "$JAVA_PATH" ; \
     tar --extract --file "$JAVA_PATH.tar.gz" --directory "$JAVA_PATH" --strip-components 1 ; \
-    $JAVA_PATH/bin/jlink --compress=2 --output /jre --add-modules java.base,java.management,java.xml,java.naming,java.sql ; \
+    $JAVA_PATH/bin/jlink --compress=2 --output /jre --add-modules java.base,java.management,java.xml,java.naming,java.sql,jdk.crypto.cryptoki; \
     /jre/bin/java -version
 
 RUN mkdir -p /perf_test_dev


### PR DESCRIPTION
Hi there! This is Stefan from Amazon MQ here. We recently noticed that this perf tool fails to connect to a RabbitMQ broker hosted in Amazon MQ due to the cipher suites that we use.

The error message is:
```
javax.net.ssl.SSLHandshakeException: Received fatal alert: insufficient_security
	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:131)
	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:117)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:337)
	at java.base/sun.security.ssl.Alert$AlertConsumer.consume(Alert.java:293)
	at java.base/sun.security.ssl.TransportContext.dispatch(TransportContext.java:186)
	at java.base/sun.security.ssl.SSLTransport.decode(SSLTransport.java:171)
	at java.base/sun.security.ssl.SSLSocketImpl.decode(SSLSocketImpl.java:1408)
	at java.base/sun.security.ssl.SSLSocketImpl.readHandshakeRecord(SSLSocketImpl.java:1314)
	at java.base/sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:440)
	at java.base/sun.security.ssl.SSLSocketImpl.ensureNegotiated(SSLSocketImpl.java:819)
	at java.base/sun.security.ssl.SSLSocketImpl$AppOutputStream.write(SSLSocketImpl.java:1189)
	at java.base/java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:81)
	at java.base/java.io.BufferedOutputStream.flush(BufferedOutputStream.java:142)
	at java.base/java.io.DataOutputStream.flush(DataOutputStream.java:123)
	at com.rabbitmq.client.impl.SocketFrameHandler.sendHeader(SocketFrameHandler.java:160)
	at com.rabbitmq.client.impl.SocketFrameHandler.sendHeader(SocketFrameHandler.java:170)
	at com.rabbitmq.client.impl.AMQConnection.start(AMQConnection.java:314)
	at com.rabbitmq.client.impl.recovery.RecoveryAwareAMQConnectionFactory.newConnection(RecoveryAwareAMQConnectionFactory.java:64)
	at com.rabbitmq.client.impl.recovery.AutorecoveringConnection.init(AutorecoveringConnection.java:156)
	at com.rabbitmq.client.ConnectionFactory.newConnection(ConnectionFactory.java:1130)
	at com.rabbitmq.client.ConnectionFactory.newConnection(ConnectionFactory.java:1087)
	at com.rabbitmq.client.ConnectionFactory.newConnection(ConnectionFactory.java:985)
	at com.rabbitmq.perf.MulticastSet$ConnectionCreator.createConfigurationConnections(MulticastSet.java:774)
	at com.rabbitmq.perf.MulticastSet.createConfigurationConnections(MulticastSet.java:284)
	at com.rabbitmq.perf.MulticastSet.run(MulticastSet.java:162)
	at com.rabbitmq.perf.PerfTest.main(PerfTest.java:353)
	at com.rabbitmq.perf.PerfTest.main(PerfTest.java:473)
```

These are the cipher suites that we use:
```
ssl_options.versions.1 = tlsv1.2
ssl_options.honor_cipher_order = true
ssl_options.honor_ecc_order = true
ssl_options.ciphers.1 = TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
ssl_options.ciphers.2 = TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
```

Adding this JRE module to the perf tool allows it to connect to brokers using these restricted cipher suites.

Please let me know if there's anything else you need!