### PR TITLE
Allow setting dead-letter-exchange to default exchange

### DIFF
--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -759,7 +759,9 @@ public class PerfTest {
         Map<String, Object> properties = new HashMap<>();
         for (String entry : arg.split(",")) {
             String [] keyValue = entry.split("=");
-            if (keyValue.length == 1) {
+            if (keyValue.length == 1 ||
+                    keyValue[0].equals("x-dead-letter-exchange") &&
+                    keyValue[1].equals("amq.default")) {
                 properties.put(keyValue[0], "");
             } else {
                 try {

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -759,10 +759,14 @@ public class PerfTest {
         Map<String, Object> properties = new HashMap<>();
         for (String entry : arg.split(",")) {
             String [] keyValue = entry.split("=");
-            try {
-                properties.put(keyValue[0], Long.parseLong(keyValue[1]));
-            } catch(NumberFormatException e) {
-                properties.put(keyValue[0], keyValue[1]);
+            if (keyValue.length == 1) {
+                properties.put(keyValue[0], "");
+            } else {
+                try {
+                    properties.put(keyValue[0], Long.parseLong(keyValue[1]));
+                } catch(NumberFormatException e) {
+                    properties.put(keyValue[0], keyValue[1]);
+                }
             }
         }
         return properties;

--- a/src/test/java/com/rabbitmq/perf/PerfTestTest.java
+++ b/src/test/java/com/rabbitmq/perf/PerfTestTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020 VMware, Inc. or its affiliates.  All rights reserved.
+// Copyright (c) 2018-2022 VMware, Inc. or its affiliates.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
@@ -15,12 +15,12 @@
 
 package com.rabbitmq.perf;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.rabbitmq.perf.PerfTest.convertKeyValuePairs;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -96,5 +96,21 @@ public class PerfTestTest {
             result.put(reason[0], Integer.parseInt(reason[1]));
         }
         return result;
+    }
+
+    @Test
+    void convertPostProcessKeyValuePairs() {
+        assertThat(convertKeyValuePairs("x-queue-type=quorum,max-length-bytes=100000"))
+            .hasSize(2)
+            .containsEntry("x-queue-type", "quorum")
+            .containsEntry("max-length-bytes", 100000L);
+        assertThat(convertKeyValuePairs("x-dead-letter-exchange=,x-queue-type=quorum"))
+            .hasSize(2)
+            .containsEntry("x-dead-letter-exchange", "")
+            .containsEntry("x-queue-type", "quorum");
+        assertThat(convertKeyValuePairs("x-dead-letter-exchange=amq.default,x-queue-type=quorum"))
+            .hasSize(2)
+            .containsEntry("x-dead-letter-exchange", "")
+            .containsEntry("x-queue-type", "quorum");
     }
 }


### PR DESCRIPTION
Default exchange has empty string.

Allow to set:
```
-qa x-dead-letter-exchange=
```

Before this commit:

```
19:03:16.359 [main] ERROR com.rabbitmq.perf.PerfTest - Main thread caught exception
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1
	at com.rabbitmq.perf.PerfTest.convertKeyValuePairs(PerfTest.java:763)
	at com.rabbitmq.perf.PerfTest.main(PerfTest.java:202)
	at com.rabbitmq.perf.PerfTest.main(PerfTest.java:527)
```