### PR TITLE
Allow `=` in a label value

### DIFF
--- a/src/main/java/com/rabbitmq/perf/BaseMetrics.java
+++ b/src/main/java/com/rabbitmq/perf/BaseMetrics.java
@@ -58,7 +58,7 @@ public class BaseMetrics implements Metrics {
         Collection<Tag> tags = new ArrayList<>();
         if (argumentTags != null) {
             for (String tag : argumentTags.split(",")) {
-                String[] keyValue = tag.split("=");
+                String[] keyValue = tag.split("=", 2);
                 tags.add(Tag.of(keyValue[0], keyValue[1]));
             }
         }


### PR DESCRIPTION
Previously metric tags were split by `=` without limits. If the value
contained `=`, the tag was split into multiple pieces and all but the
first two were discarded. With this change, the value containing `=`,
which is a valid label value, is correctly supported.

I admit it's a corner case but I'm using `-mt` to expose perf-test command line flags as a label so it's easy to see what workload was running at a given time. Since the command line may contain, for example, `--queue-args "x-max-length=100000"`, this change is necessary to parse the whole thing correctly.

Side note, we could consider exposing a metric with perf-test's configuration automatically, similar to `rabbitmq_identity_info` metric, so that `-mt perftest_flags=...` is not necessary for me.