### PR TITLE
Schedule re-subscription if necessary after node restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You need a local running RabbitMQ instance.
 
 Start a RabbitMQ container:
 
-    docker run -it --rm --name rabbitmq -p 5672:5672 rabbitmq:3.8
+    docker run -it --rm --name rabbitmq -p 5672:5672 rabbitmq:3.10
 
 Run the test suite:
 

--- a/src/main/java/com/rabbitmq/perf/AgentBase.java
+++ b/src/main/java/com/rabbitmq/perf/AgentBase.java
@@ -30,6 +30,16 @@ public abstract class AgentBase {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AgentBase.class);
 
+    private volatile TopologyRecording topologyRecording;
+
+    public void setTopologyRecording(TopologyRecording topologyRecording) {
+        this.topologyRecording = topologyRecording;
+    }
+
+    protected TopologyRecording topologyRecording() {
+        return this.topologyRecording;
+    }
+
     protected void delay(long now, AgentState state) {
 
         long elapsed = now - state.getLastStatsTime();

--- a/src/main/java/com/rabbitmq/perf/ConsumerParameters.java
+++ b/src/main/java/com/rabbitmq/perf/ConsumerParameters.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 VMware, Inc. or its affiliates.  All rights reserved.
+// Copyright (c) 2019-2022 VMware, Inc. or its affiliates.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
@@ -21,6 +21,7 @@ import com.rabbitmq.perf.PerfTest.EXIT_WHEN;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  *
@@ -51,6 +52,8 @@ public class ConsumerParameters {
     private EXIT_WHEN exitWhen = EXIT_WHEN.NEVER;
 
     private Map<String, Object> consumerArguments = null;
+
+    private ScheduledExecutorService topologyRecoveryScheduledExecutorService;
 
     public Channel getChannel() {
         return channel;
@@ -230,5 +233,15 @@ public class ConsumerParameters {
 
     public EXIT_WHEN getExitWhen() {
         return exitWhen;
+    }
+
+    ConsumerParameters setTopologyRecoveryScheduledExecutorService(
+        ScheduledExecutorService topologyRecoveryScheduledExecutorService) {
+        this.topologyRecoveryScheduledExecutorService = topologyRecoveryScheduledExecutorService;
+        return this;
+    }
+
+    public ScheduledExecutorService getTopologyRecoveryScheduledExecutorService() {
+        return topologyRecoveryScheduledExecutorService;
     }
 }

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -406,6 +406,7 @@ public class PerfTest {
             p.setConsumerArguments(convertKeyValuePairs(consumerArgs));
             p.setQueuesInSequence(queueFile != null);
             p.setExitWhen(exitWhen);
+            p.setCluster(uris.size() > 0);
 
             ConcurrentMap<String, Integer> completionReasons = new ConcurrentHashMap<>();
 

--- a/src/main/java/com/rabbitmq/perf/Recovery.java
+++ b/src/main/java/com/rabbitmq/perf/Recovery.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+// Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
@@ -57,6 +57,7 @@ public class Recovery {
                 @Override
                 public void init(AgentBase agent) {
                     agentReference.set(agent);
+                    agent.setTopologyRecording(topologyRecording);
                 }
 
                 @Override
@@ -74,6 +75,7 @@ public class Recovery {
 
                 @Override
                 public void handleRecoveryStarted(Recoverable recoverable) {
+                    // FIXME use lock to avoid start topology recovery twice
                     recoveryInProgress.set(true);
                 }
 

--- a/src/test/java/com/rabbitmq/perf/ConnectionRecoveryTest.java
+++ b/src/test/java/com/rabbitmq/perf/ConnectionRecoveryTest.java
@@ -1,0 +1,229 @@
+// Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+//
+// This software, the RabbitMQ Java client library, is triple-licensed under the
+// Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
+// ("GPL") and the Apache License version 2 ("ASL"). For the MPL, please see
+// LICENSE-MPL-RabbitMQ. For the GPL, please see LICENSE-GPL2.  For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+
+package com.rabbitmq.perf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.AMQP.Queue.DeclareOk;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.Consumer;
+import com.rabbitmq.client.RecoveryListener;
+import com.rabbitmq.client.ShutdownListener;
+import com.rabbitmq.client.ShutdownSignalException;
+import com.rabbitmq.client.impl.AMQImpl;
+import com.rabbitmq.client.impl.AMQImpl.Channel.Close;
+import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+/** */
+public class ConnectionRecoveryTest {
+
+  private static final String QUEUE = "test-queue";
+  @Mock ConnectionFactory cf;
+  @Mock AutorecoveringConnection c;
+  @Mock Channel ch;
+  @Mock Stats stats;
+  @Mock MulticastSet.ThreadingHandler threadingHandler;
+  @Mock ExecutorService executorService;
+  @Mock ScheduledExecutorService scheduledExecutorService;
+  @Mock Future future;
+  MulticastParams params;
+  AutoCloseable mocks;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  public void init() throws Exception {
+    mocks = openMocks(this);
+
+    when(cf.newConnection(anyList(), anyString())).thenReturn(c);
+    when(c.createChannel()).thenReturn(ch);
+    when(c.getClientProvidedName()).thenReturn("consumer-connection");
+    DeclareOk declareOk = new AMQImpl.Queue.DeclareOk(QUEUE, 0, 0);
+    when(ch.queueDeclare(eq(QUEUE), anyBoolean(), anyBoolean(), anyBoolean(), anyMap()))
+        .thenReturn(declareOk);
+    when(ch.queueDeclare(eq(QUEUE), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+        .thenReturn(declareOk);
+    when(ch.getConnection()).thenReturn(c);
+    when(ch.queueDeclarePassive(QUEUE))
+        .thenThrow(
+            new IOException(
+                new ShutdownSignalException(
+                    false, false, new Close(AMQP.NOT_FOUND, "", 0, 0), null)))
+        .thenReturn(declareOk);
+
+    when(threadingHandler.executorService(anyString(), anyInt())).thenReturn(executorService);
+    when(threadingHandler.scheduledExecutorService(anyString(), anyInt()))
+        .thenReturn(scheduledExecutorService);
+    when(executorService.submit(any(Runnable.class))).thenReturn(future);
+
+    params = new MulticastParams();
+    params.setQueueNames(Collections.singletonList(QUEUE));
+    params.setAutoDelete(false);
+    params.setExclusive(false);
+    params.setFlags(Collections.singletonList("persistent"));
+    params.setCluster(true);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    mocks.close();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void subscriptionShouldBeScheduledIfQueueDoesNotExist() throws Exception {
+    // for https://github.com/rabbitmq/rabbitmq-perf-test/issues/330
+    List<RecoveryListener> recoveryListeners = Collections.synchronizedList(new ArrayList<>());
+    doAnswer(
+            invocation -> {
+              recoveryListeners.add(invocation.getArgument(0, RecoveryListener.class));
+              return null;
+            })
+        .when(c)
+        .addRecoveryListener(any(RecoveryListener.class));
+    List<ShutdownListener> shutdownListeners = Collections.synchronizedList(new ArrayList<>());
+    doAnswer(
+            invocation -> {
+              shutdownListeners.add(invocation.getArgument(0, ShutdownListener.class));
+              return null;
+            })
+        .when(c)
+        .addShutdownListener(any(ShutdownListener.class));
+    CountDownLatch completionLatch = new CountDownLatch(1);
+    CountDownLatch runStartedLatch = new CountDownLatch(1);
+    new Thread(
+            () -> {
+              try {
+                MulticastSet set = getMulticastSet(runStartedLatch, completionLatch);
+                set.run();
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .start();
+
+    assertThat(runStartedLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+    assertThat(recoveryListeners)
+        .hasSize(5); // configuration x 3 (cluster) + consumer + producer connections
+    assertThat(shutdownListeners).hasSize(2); // consumer + producer connections
+
+    // initial subscription
+    verify(ch, times(1))
+        .basicConsume(anyString(), anyBoolean(), nullable(Map.class), any(Consumer.class));
+    // subscription after recovery, not called yet
+    verify(ch, never())
+        .basicConsume(
+            anyString(),
+            anyBoolean(),
+            anyString(),
+            anyBoolean(),
+            anyBoolean(),
+            nullable(Map.class),
+            any(Consumer.class));
+
+    // synchronously call the scheduled subscription
+    doAnswer(
+            invocation -> {
+              Callable<?> action = invocation.getArgument(0);
+              action.call();
+              return null;
+            })
+        .when(scheduledExecutorService)
+        .schedule(any(Callable.class), anyLong(), any(TimeUnit.class));
+
+    RecoveryListener consumerRecoveryListener = recoveryListeners.get(3);
+    ShutdownListener consumerShutdownListener = shutdownListeners.get(1);
+
+    // mimic connection recovery
+    consumerShutdownListener.shutdownCompleted(
+        new ShutdownSignalException(false, true, null, null));
+    consumerRecoveryListener.handleRecoveryStarted(null);
+    consumerRecoveryListener.handleRecovery(null);
+
+    // first check fails, second check says the queue exists
+    verify(ch, times(2)).queueDeclarePassive(QUEUE);
+    // initial subscription, still the same
+    verify(ch, times(1))
+        .basicConsume(anyString(), anyBoolean(), nullable(Map.class), any(Consumer.class));
+    // subscription after recovery
+    verify(ch, times(1))
+        .basicConsume(
+            anyString(),
+            anyBoolean(),
+            nullable(String.class),
+            anyBoolean(),
+            anyBoolean(),
+            nullable(Map.class),
+            any(Consumer.class));
+  }
+
+  private MulticastSet getMulticastSet(
+      CountDownLatch runStartedLatch, CountDownLatch completionLatch) {
+    MulticastSet set =
+        new MulticastSet(
+            stats,
+            cf,
+            params,
+            Arrays.asList("amqp://localhost", "amqp://localhost", "amqp://localhost"),
+            new MulticastSet.CompletionHandler() {
+
+              @Override
+              public void waitForCompletion() throws InterruptedException {
+                runStartedLatch.countDown();
+                completionLatch.await(10, TimeUnit.SECONDS);
+              }
+
+              @Override
+              public void countDown(String reason) {}
+            });
+    set.setThreadingHandler(threadingHandler);
+    return set;
+  }
+}

--- a/src/test/java/com/rabbitmq/perf/SequenceTopologyHandlerTest.java
+++ b/src/test/java/com/rabbitmq/perf/SequenceTopologyHandlerTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020 VMware, Inc. or its affiliates.  All rights reserved.
+// Copyright (c) 2018-2022 VMware, Inc. or its affiliates.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
@@ -26,7 +26,7 @@ public class SequenceTopologyHandlerTest {
 
     @Test
     public void sequence() {
-        handler = new MulticastParams.SequenceTopologyHandler(null, 1, 5, "test-%d", new TopologyRecording(false), null);
+        handler = new MulticastParams.SequenceTopologyHandler(null, 1, 5, "test-%d", new TopologyRecording(false, false), null);
         assertThat(handler.getQueueNames()).hasSize(5).contains("test-1", "test-2", "test-3", "test-4", "test-5");
 
         assertThat(handler.getRoutingKey()).isEqualTo("test-1");
@@ -51,7 +51,7 @@ public class SequenceTopologyHandlerTest {
 
     @Test
     public void useFixedRoutingKeyWhenProvided() {
-        handler = new MulticastParams.SequenceTopologyHandler(null, 1, 5, "test-%d", new TopologyRecording(false), "rk");
+        handler = new MulticastParams.SequenceTopologyHandler(null, 1, 5, "test-%d", new TopologyRecording(false, false), "rk");
         assertThat(handler.getQueueNames()).hasSize(5).contains("test-1", "test-2", "test-3", "test-4", "test-5");
 
         assertThat(handler.getQueueNamesForClient()).hasSize(1).contains("test-1");
@@ -63,7 +63,7 @@ public class SequenceTopologyHandlerTest {
 
     @Test
     public void reset() {
-        handler = new MulticastParams.SequenceTopologyHandler(null, 1, 100, "test-%d", new TopologyRecording(false), null);
+        handler = new MulticastParams.SequenceTopologyHandler(null, 1, 100, "test-%d", new TopologyRecording(false, false), null);
         assertThat(handler.getQueueNames()).hasSize(100);
 
         assertThat(handler.getRoutingKey()).isEqualTo("test-1");
@@ -86,7 +86,7 @@ public class SequenceTopologyHandlerTest {
 
     @Test
     public void format() {
-        handler = new MulticastParams.SequenceTopologyHandler(null, 1, 5, "test-%03d", new TopologyRecording(false), null);
+        handler = new MulticastParams.SequenceTopologyHandler(null, 1, 5, "test-%03d", new TopologyRecording(false, false), null);
         assertThat(handler.getQueueNames()).hasSize(5).contains("test-001", "test-002", "test-003", "test-004", "test-005");
     }
 }


### PR DESCRIPTION
Necessary = queue does not exist if classic queue, durable,
and in a cluster setup. In such a case, the queue "does
not exist" as long as the node is down and becomes available
again when the node restarts. Consumers on other nodes
are then scheduled to subscribe for some time.

Fixes #330