### PR TITLE
Revert "Bump jruby-complete from 9.3.4.0 to 9.3.6.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
 
     <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
     <asciidoctorj.version>2.5.4</asciidoctorj.version>
-    <jruby.version>9.3.6.0</jruby.version>
+    <jruby.version>9.3.4.0</jruby.version>
     <!-- For GraalVM native image -->
     <slf4j.version>1.7.36</slf4j.version>
     <graal-sdk.version>22.1.0.1</graal-sdk.version>


### PR DESCRIPTION
Reverts rabbitmq/rabbitmq-perf-test#348

Not compatible with AsciiDoctor.