### PR TITLE
Add topology recovery in cancel handler

### DIFF
--- a/src/main/java/com/rabbitmq/perf/Consumer.java
+++ b/src/main/java/com/rabbitmq/perf/Consumer.java
@@ -323,7 +323,7 @@ public class Consumer extends AgentBase implements Runnable {
 
         @Override
         public void handleCancel(String consumerTag) throws IOException {
-            System.out.printf("Consumer cancelled by broker for tag: %s", consumerTag);
+            System.out.printf("Consumer cancelled by broker for tag: %s\n", consumerTag);
             epochMessageCount.set(0);
             if (consumerTagBranchMap.containsKey(consumerTag)) {
                 String qName = consumerTagBranchMap.get(consumerTag);
@@ -331,7 +331,7 @@ public class Consumer extends AgentBase implements Runnable {
                 RecordedQueue queueRecord = topologyRecording.queue(qName);
                 consumeOrScheduleConsume(queueRecord, topologyRecording, consumerTag, qName);
             } else {
-                System.out.printf("Could not find queue for consumer tag: %s", consumerTag);
+                System.out.printf("Could not find queue for consumer tag: %s\n", consumerTag);
             }
         }
     }
@@ -393,6 +393,7 @@ public class Consumer extends AgentBase implements Runnable {
                 channel.basicConsume(queueName, autoAck, consumerTag, false, false, this.consumerArguments, q);
             } else {
                 LOGGER.debug("Queue {} does not exist, it is likely unavailable, scheduling subscription.", queueName);
+                topologyRecording.recoverQueueAndBindings(channel.getConnection(), queueRecord);
                 Duration schedulingPeriod = Duration.ofSeconds(5);
                 int maxRetry = (int) (Duration.ofMinutes(10).getSeconds() / schedulingPeriod.getSeconds());
                 AtomicInteger retryCount = new AtomicInteger(0);

--- a/src/main/java/com/rabbitmq/perf/TopologyRecording.java
+++ b/src/main/java/com/rabbitmq/perf/TopologyRecording.java
@@ -169,49 +169,7 @@ public class TopologyRecording {
             Channel channel = connection.createChannel();
             for (Map.Entry<String, RecordedQueue> entry : queues.entrySet()) {
                 RecordedQueue queue = entry.getValue();
-                synchronized (queue) {
-                    String originalName = queue.name;
-                    LOGGER.debug("Connection {}, recovering queue {}", connection.getClientProvidedName(), queue);
-                    boolean redeclare = true;
-                    // the queue may still be around (e.g. a quorum queue in a cluster)
-                    // so checking if it's necessary to create it
-                    if (queue.durable && queue.serverNamed && !queue.autoDelete && !queue.exclusive) {
-                        // so in this case, the server-named queue won't be renamed
-                        try {
-                            channel.queueDeclarePassive(queue.name);
-                            // the queue exists
-                            redeclare = false;
-                        } catch (IOException e) {
-                            // the queue does not exists
-                            redeclare = true;
-                            channel = connection.createChannel();
-                        }
-                    }
-                    if (redeclare) {
-                        LOGGER.debug("Trying to re-declare queue {}", originalName);
-                        channel = reliableWrite(connection, channel, ch -> {
-                            String newName = ch.queueDeclare(
-                                    queue.serverNamed ? "" : queue.name, queue.durable, queue.exclusive,
-                                    queue.autoDelete, queue.arguments
-                            ).getQueue();
-                            LOGGER.debug("Re-declared queue {}", originalName);
-                            queue.name = newName;
-                            if (queue.serverNamed) {
-                                LOGGER.debug("Queue {} was server-named, it is now {}", originalName, newName);
-                            }
-                        }, () -> "Error while trying to re-declare queue " + originalName);
-                    }
-
-                    LOGGER.debug("Connection {}, recovered queue {}", connection.getClientProvidedName(), queue);
-
-                    // Recovering an auto-delete, server-named queue create a brand new queue, with a new name.
-                    // This is not fine with polling, as the former server-named queue is still around: no consumer
-                    // registered to it.
-                    // so we delete this former queue explicitly when polling.
-                    if (this.polling && queue.autoDelete && queue.serverNamed && !queue.exclusive) {
-                        channel = reliableWrite(connection, channel, ch -> ch.queueDelete(originalName));
-                    }
-                }
+                channel = recoverQueue(channel, queue);
             }
             for (RecordedExchange exchange : exchanges.values()) {
                 LOGGER.debug("Connection {}, recovering exchange {}", connection.getClientProvidedName(), exchange);
@@ -245,25 +203,78 @@ public class TopologyRecording {
         }
     }
 
-    public void recoverQueueAndBindings(Connection connection, RecordedQueue queueRecord) {
-        String queueName = queueRecord.name();
-        try {
-            Channel ch = connection.createChannel();
-            ch.queueDeclare(queueName,
-                            queueRecord.isDurable(),
-                            queueRecord.isExclusive(),
-                            queueRecord.isAutoDelete(),
-                            queueRecord.getArguments());
-
-            Collection<TopologyRecording.RecordedBinding> bindingsForQ = getBindingsFor(queueName);
-            for (TopologyRecording.RecordedBinding binding : bindingsForQ) {
-                ch.queueBind(queueName, binding.getExchange(), binding.routingKeyIsQueue() ? queueName : binding.routingKey);
+    private Channel recoverQueue(Channel channel, RecordedQueue queue) throws IOException {
+        Connection connection = channel.getConnection();
+        synchronized (queue) {
+            String originalName = queue.name;
+            LOGGER.debug("Connection {}, recovering queue {}", connection.getClientProvidedName(), queue);
+            boolean redeclare = true;
+            // the queue may still be around (e.g. a quorum queue in a cluster)
+            // so checking if it's necessary to create it
+            if (queue.durable && queue.serverNamed && !queue.autoDelete && !queue.exclusive) {
+                // so in this case, the server-named queue won't be renamed
+                try {
+                    channel.queueDeclarePassive(queue.name);
+                    // the queue exists
+                    redeclare = false;
+                } catch (IOException e) {
+                    // the queue does not exist
+                    redeclare = true;
+                    channel = connection.createChannel();
+                }
             }
-            ch.close();
+            if (redeclare) {
+                LOGGER.debug("Trying to re-declare queue {}", originalName);
+                channel = reliableWrite(connection, channel, ch -> {
+                    String newName = ch.queueDeclare(
+                        queue.serverNamed ? "" : queue.name, queue.durable, queue.exclusive,
+                        queue.autoDelete, queue.arguments
+                    ).getQueue();
+                    LOGGER.debug("Re-declared queue {}", originalName);
+                    queue.name = newName;
+                    if (queue.serverNamed) {
+                        LOGGER.debug("Queue {} was server-named, it is now {}", originalName, newName);
+                    }
+                }, () -> "Error while trying to re-declare queue " + originalName);
+            }
+
+            LOGGER.debug("Connection {}, recovered queue {}", connection.getClientProvidedName(), queue);
+
+            // Recovering an auto-delete, server-named queue creates a brand new queue, with a new name.
+            // This is not fine with polling, as the former server-named queue is still around: no consumer
+            // registered to it.
+            // so we delete this former queue explicitly when polling.
+            if (this.polling && queue.autoDelete && queue.serverNamed && !queue.exclusive) {
+                channel = reliableWrite(connection, channel, ch -> ch.queueDelete(originalName));
+            }
+        }
+        return channel;
+    }
+
+    void recoverQueueAndBindings(Connection connection, RecordedQueue queueRecord) {
+        Channel ch = null;
+        try {
+            ch = connection.createChannel();
+            // the queue name may change(server-named queue)
+            String oldQueueName = queueRecord.name();
+            ch = recoverQueue(ch, queueRecord);
+            String newQueueName = queueRecord.name();
+            Collection<TopologyRecording.RecordedBinding> bindingsForQ = getBindingsFor(oldQueueName);
+            for (TopologyRecording.RecordedBinding binding : bindingsForQ) {
+                ch.queueBind(newQueueName, binding.getExchange(), binding.routingKeyIsQueue() ? newQueueName : binding.routingKey);
+            }
         } catch (Exception e) {
             LOGGER.warn("Exception during Queue and Binding recovery for connection {}: {}",
                     connection.getClientProvidedName(),
                     e.getMessage());
+        } finally {
+            if (ch != null) {
+                try {
+                    ch.close();
+                } catch (Exception e) {
+                    // OK
+                }
+            }
         }
     }
 

--- a/src/test/java/com/rabbitmq/perf/it/MiscellaneousIT.java
+++ b/src/test/java/com/rabbitmq/perf/it/MiscellaneousIT.java
@@ -19,6 +19,8 @@ import static com.rabbitmq.perf.TestUtils.threadFactory;
 import static com.rabbitmq.perf.TestUtils.waitAtMost;
 import static com.rabbitmq.perf.it.Utils.latchCompletionHandler;
 import static com.rabbitmq.perf.it.Utils.queueName;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
@@ -29,13 +31,13 @@ import com.rabbitmq.perf.Stats;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,7 +48,7 @@ import org.slf4j.LoggerFactory;
 public class MiscellaneousIT {
 
   static final String URI = "amqp://localhost";
-  static final List<String> URIS = Collections.singletonList(URI);
+  static final List<String> URIS = singletonList(URI);
   private static final Logger LOGGER = LoggerFactory.getLogger(MiscellaneousIT.class);
   MulticastParams params;
 
@@ -56,12 +58,14 @@ public class MiscellaneousIT {
 
   AtomicBoolean testIsDone;
   CountDownLatch testLatch;
+  AtomicInteger msgConsumed;
 
-  Stats stats =
-      new Stats(1000, false, new CompositeMeterRegistry(), "") {
-        @Override
-        protected void report(long now) {}
-      };
+  Stats stats = new Stats(1000, false, new CompositeMeterRegistry(), "") {
+    @Override
+    protected void report(long now) {
+      msgConsumed.set(recvCountTotal);
+    }
+  };
 
   @BeforeEach
   public void init(TestInfo info) {
@@ -70,6 +74,7 @@ public class MiscellaneousIT {
     cf = new ConnectionFactory();
     testIsDone = new AtomicBoolean(false);
     testLatch = new CountDownLatch(1);
+    msgConsumed = new AtomicInteger(0);
   }
 
   @AfterEach
@@ -106,7 +111,7 @@ public class MiscellaneousIT {
     }
 
     // using the pre-defined queue
-    params.setQueueNames(Collections.singletonList(queue));
+    params.setQueueNames(singletonList(queue));
     params.setRoutingKey(queue);
     params.setPredeclared(true);
     // 1 consumer only
@@ -119,8 +124,8 @@ public class MiscellaneousIT {
     params.setConsumerPrefetch(10);
 
     try {
-      MulticastSet set =
-          new MulticastSet(stats, cf, params, "", URIS, latchCompletionHandler(1, info));
+      MulticastSet set = new MulticastSet(stats, cf, params, "", URIS,
+          latchCompletionHandler(1, info));
       run(set);
 
       waitAtMost(180, () -> testIsDone.get());
@@ -132,19 +137,82 @@ public class MiscellaneousIT {
     }
   }
 
+  @Test
+  void consumerShouldRecoverWhenServerNamedQueueIsDeleted(TestInfo info) throws Exception {
+    int rate = 100;
+    params.setProducerCount(1);
+    params.setConsumerCount(1);
+    params.setProducerRateLimit(rate);
+
+    List<String> queuesBeforeTest = Host.listQueues();
+
+    MulticastSet.CompletionHandler completionHandler = latchCompletionHandler(1, info);
+    MulticastSet set = new MulticastSet(stats, cf, params, "", URIS, completionHandler);
+    run(set);
+
+    waitAtMost(10, () -> msgConsumed.get() >= 3 * rate);
+    List<String> queuesDuringTest = Host.listQueues();
+    queuesDuringTest.removeAll(queuesBeforeTest);
+    assertThat(queuesDuringTest).hasSize(1);
+    String queue = queuesDuringTest.get(0);
+
+    ConnectionFactory connectionFactory = new ConnectionFactory();
+    int messageConsumedBeforeDeletion;
+    try (Connection c = connectionFactory.newConnection()) {
+      Channel ch = c.createChannel();
+      messageConsumedBeforeDeletion = msgConsumed.get();
+      ch.queueDelete(queue);
+    }
+
+    assertThat(messageConsumedBeforeDeletion).isPositive();
+    waitAtMost(10, () -> msgConsumed.get() >= messageConsumedBeforeDeletion + 3 * rate);
+
+    completionHandler.countDown("stopped in test");
+    waitAtMost(10, () -> testIsDone.get());
+  }
+
+  @Test
+  void consumerShouldRecoverWhenQueueIsDeleted(TestInfo info) throws Exception {
+    String queue = queueName(info);
+    int rate = 100;
+    params.setProducerCount(1);
+    params.setConsumerCount(1);
+    params.setProducerRateLimit(rate);
+    params.setQueueNames(singletonList(queue));
+
+    MulticastSet.CompletionHandler completionHandler = latchCompletionHandler(1, info);
+    MulticastSet set = new MulticastSet(stats, cf, params, "", URIS, completionHandler);
+    run(set);
+
+    waitAtMost(10, () -> msgConsumed.get() >= 3 * rate);
+
+    ConnectionFactory connectionFactory = new ConnectionFactory();
+    int messageConsumedBeforeDeletion;
+    try (Connection c = connectionFactory.newConnection()) {
+      Channel ch = c.createChannel();
+      messageConsumedBeforeDeletion = msgConsumed.get();
+      ch.queueDelete(queue);
+    }
+
+    assertThat(messageConsumedBeforeDeletion).isPositive();
+    waitAtMost(10, () -> msgConsumed.get() >= messageConsumedBeforeDeletion + 3 * rate);
+
+    completionHandler.countDown("stopped in test");
+    waitAtMost(10, () -> testIsDone.get());
+  }
+
   private void run(MulticastSet multicastSet) {
-    executorService.submit(
-        () -> {
-          try {
-            multicastSet.run();
-            testIsDone.set(true);
-            testLatch.countDown();
-          } catch (InterruptedException e) {
-            // one of the tests stops the execution, no need to be noisy
-            throw new RuntimeException(e);
-          } catch (Exception e) {
-            e.printStackTrace();
-          }
-        });
+    executorService.submit(() -> {
+      try {
+        multicastSet.run();
+        testIsDone.set(true);
+        testLatch.countDown();
+      } catch (InterruptedException e) {
+        // one of the tests stops the execution, no need to be noisy
+        throw new RuntimeException(e);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    });
   }
 }


### PR DESCRIPTION
## Summary

- Adding partial topology recovery in consumer cancel handler

## Context

The consumer cancel handler attempts to re-subscribe when it receives
the cancellation frame. This works for cases when a CQ hosting node is
down, and eventually comes up; or when a CQ is down for some reason, and
later on recovers.

That logic, however, does not account for a topology change e.g. a queue
deletion. A queue deletion also sends a consumer cancel frame. In this
situation, we have to do a partial topology recovery. In this case, we
have to re-declare the queue and its bindings.

