### PR TITLE
Convert x-single-active-consumer to a bool

### DIFF
--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -785,6 +785,9 @@ public class PerfTest {
         }).map(keyValue -> {
             if ("x-dead-letter-exchange".equals(keyValue[0]) && "amq.default".equals(keyValue[1])) {
                 return new String[] {"x-dead-letter-exchange", ""};
+            }
+            else if ("x-single-active-consumer".equals(keyValue[0])) {
+                return new Object[] {"x-single-active-consumer", Boolean.parseBoolean(String.valueOf(keyValue[1]))};
             } else {
                 return keyValue;
             }


### PR DESCRIPTION
Without this change, `--queue-args x-single-active-consumer=true` failed with PRECONDITION_FAILED `{unacceptable_type,longstr}`.