### PR TITLE
Use millisecond granularity for publisher ramp-up period

### DIFF
--- a/src/main/java/com/rabbitmq/perf/MulticastSet.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastSet.java
@@ -456,8 +456,9 @@ public class MulticastSet {
             Supplier<Duration> startDelaySupplier;
             if (params.getProducerRandomStartDelayInSeconds() > 0) {
                 Random random = new Random();
-                startDelaySupplier = () -> Duration.ofSeconds(
-                    random.nextInt(params.getProducerRandomStartDelayInSeconds()) + 1
+                int bound = params.getProducerRandomStartDelayInSeconds() * 1000;
+                startDelaySupplier = () -> Duration.ofMillis(
+                    random.nextInt(bound) + 1
                 );
             } else {
                 startDelaySupplier = () -> Duration.ZERO;


### PR DESCRIPTION
It was seconds, which works for very long ramp-up period (e.g. 60 seconds or more) and a small number of publishers (few 100s), but not short ramp-up period and large numbers of publishers (start 5000 publishers in 15 seconds). In such cases, the workload was not random enough like in real-life and metrics like publisher confirm latency could be much higher than expected.

References #394