### PR TITLE
Set 1s random start delay when producer rate is set

### DIFF
--- a/src/main/java/com/rabbitmq/perf/MulticastSet.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastSet.java
@@ -455,12 +455,15 @@ public class MulticastSet {
             );
             Supplier<Duration> startDelaySupplier;
             if (params.getProducerRandomStartDelayInSeconds() > 0) {
+                LOGGER.debug("Using random start-up delay for producers, from 1 ms to {} s",
+                    params.getProducerRandomStartDelayInSeconds());
                 Random random = new Random();
                 int bound = params.getProducerRandomStartDelayInSeconds() * 1000;
                 startDelaySupplier = () -> Duration.ofMillis(
                     random.nextInt(bound) + 1
                 );
             } else {
+                LOGGER.debug("No start-up delay for producers, they are starting ASAP");
                 startDelaySupplier = () -> Duration.ZERO;
             }
             Duration publishingInterval = params.getPublishingInterval();

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -168,6 +168,12 @@ public class PerfTest {
                 }
             }
 
+            if ((!variableRates.isEmpty() || producerRateLimit >= 0 || publishingInterval != null)
+                && producerRandomStartDelayInSeconds < 0) {
+                // producer rate instructions, but no ramp-up period, so setting it to 1 second
+                producerRandomStartDelayInSeconds = 1;
+            }
+
             List<String> variableSizes = lstArg(cmd, "vs");
             if (variableSizes != null && !variableSizes.isEmpty()) {
                 for (String variableSize : variableSizes) {


### PR DESCRIPTION
Use a default 1 second random start delay when producer rate instructions are specified. Use the one specified by the user (including 0, meaning no delay) otherwise.

References #401