### PR TITLE
Use atomic utilities instead of synchronization in stats

### DIFF
--- a/src/main/java/com/rabbitmq/perf/Consumer.java
+++ b/src/main/java/com/rabbitmq/perf/Consumer.java
@@ -252,7 +252,7 @@ public class Consumer extends AgentBase implements Runnable {
 
         private ConsumerImpl(Channel channel) {
             super(channel);
-            state.setLastStatsTime(System.currentTimeMillis());
+            state.setLastStatsTime(System.nanoTime());
             state.setMsgCount(0);
         }
 
@@ -278,7 +278,7 @@ public class Consumer extends AgentBase implements Runnable {
                     commitTransactionIfNecessary(epochMessageCount.get(), ch);
                     lastDeliveryTag = envelope.getDeliveryTag();
 
-                    long now = System.currentTimeMillis();
+                    long now = System.nanoTime();
                     if (rateLimitation) {
                         // if rate is limited, we need to reset stats every second
                         // otherwise pausing to throttle rate will be based on the whole history

--- a/src/main/java/com/rabbitmq/perf/MulticastSet.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastSet.java
@@ -130,7 +130,7 @@ public class MulticastSet {
         }
 
         this.connectionCreator = new ConnectionCreator(this.factory, this.uris);
-        if (stats.interval() > 0) {
+        if (stats.interval().toMillis() > 0) {
             this.threadingHandler.scheduledExecutorService("perf-test-stats-activity-check-", 1)
                 .scheduleAtFixedRate(() -> {
                     try {
@@ -138,7 +138,7 @@ public class MulticastSet {
                     } catch (Exception e) {
                         LOGGER.warn("Error while checking stats activity: {}", e.getMessage());
                     }
-                }, stats.interval() * 2, stats.interval(), TimeUnit.MILLISECONDS);
+                }, stats.interval().toMillis() * 2, stats.interval().toMillis(), TimeUnit.MILLISECONDS);
         }
     }
 

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -23,7 +23,6 @@ import com.rabbitmq.client.impl.ClientVersion;
 import com.rabbitmq.client.impl.DefaultExceptionHandler;
 import com.rabbitmq.client.impl.nio.NioParams;
 import com.rabbitmq.perf.Metrics.ConfigurationContext;
-import com.rabbitmq.perf.ShutdownService.CloseCallback;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -285,7 +284,7 @@ public class PerfTest {
 
             //setup
             PrintlnStats stats = new PrintlnStats(testID,
-                1000L * samplingInterval,
+                Duration.ofSeconds(samplingInterval),
                 producerCount > 0,
                 consumerCount > 0,
                 (flags.contains("mandatory") || flags.contains("immediate")),

--- a/src/main/java/com/rabbitmq/perf/Producer.java
+++ b/src/main/java/com/rabbitmq/perf/Producer.java
@@ -367,7 +367,7 @@ public class Producer extends AgentBase implements Runnable, ReturnListener,
         }
         long now;
         final long startTime;
-        startTime = System.currentTimeMillis();
+        startTime = System.nanoTime();
         ProducerState state = new ProducerState();
         state.setLastStatsTime(startTime);
         state.setMsgCount(0);
@@ -381,7 +381,7 @@ public class Producer extends AgentBase implements Runnable, ReturnListener,
                 } else {
                     handlePublish(state);
                 }
-                now = System.currentTimeMillis();
+                now = System.nanoTime();
                 // if rate is variable, we need to reset producer stats every second
                 // otherwise pausing to throttle rate will be based on the whole history
                 // which is broken when rate varies
@@ -479,7 +479,7 @@ public class Producer extends AgentBase implements Runnable, ReturnListener,
         };
         return () -> {
             if (initialized.compareAndSet(false, true)) {
-                state.setLastStatsTime(System.currentTimeMillis());
+                state.setLastStatsTime(System.nanoTime());
                 state.setMsgCount(0);
             }
             try {

--- a/src/test/java/com/rabbitmq/perf/NoOpStats.java
+++ b/src/test/java/com/rabbitmq/perf/NoOpStats.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020 VMware, Inc. or its affiliates.  All rights reserved.
+// Copyright (c) 2018-2022 VMware, Inc. or its affiliates.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
@@ -16,6 +16,7 @@
 package com.rabbitmq.perf;
 
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import java.time.Duration;
 
 /**
  *
@@ -23,7 +24,7 @@ import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 public class NoOpStats extends Stats {
 
     public NoOpStats() {
-        super(1000, false, new CompositeMeterRegistry(), "");
+        super(Duration.ofMillis(1000), false, new CompositeMeterRegistry(), "");
     }
 
     @Override

--- a/src/test/java/com/rabbitmq/perf/PerfTestMultiTest.java
+++ b/src/test/java/com/rabbitmq/perf/PerfTestMultiTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 VMware, Inc. or its affiliates.  All rights reserved.
+// Copyright (c) 2019-2022 VMware, Inc. or its affiliates.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
@@ -64,9 +64,9 @@ public class PerfTestMultiTest {
     public void simpleScenarioStatsJsonWriting() {
         SimpleScenarioStats stats = new SimpleScenarioStats(1000);
         stats.handleSend();
-        stats.report(System.currentTimeMillis());
+        stats.report(System.nanoTime());
         stats.handleSend();
-        stats.report(System.currentTimeMillis());
+        stats.report(System.nanoTime());
         String json = PerfTestMulti.toJson(stats.results());
         Map<String, Object> results = gson().fromJson(json, Map.class);
         assertThat(results).hasSize(5);
@@ -87,11 +87,11 @@ public class PerfTestMultiTest {
     public void varyingScenarioStatsJsonWriting() {
         VaryingScenarioStats varyingScenarioStats = new VaryingScenarioStats();
         SimpleScenarioStats stats = varyingScenarioStats.next(Arrays.asList(new MulticastValue("minMsgSize", 100)));
-        stats.report(System.currentTimeMillis());
-        stats.report(System.currentTimeMillis());
+        stats.report(System.nanoTime());
+        stats.report(System.nanoTime());
         stats = varyingScenarioStats.next(Arrays.asList(new MulticastValue("minMsgSize", 200)));
-        stats.report(System.currentTimeMillis());
-        stats.report(System.currentTimeMillis());
+        stats.report(System.nanoTime());
+        stats.report(System.nanoTime());
         String json = PerfTestMulti.toJson(varyingScenarioStats.results());
         Map<String, Object> results = gson().fromJson(json, Map.class);
         assertThat(results).hasSize(3).containsKeys("data", "dimension-values", "dimensions");

--- a/src/test/java/com/rabbitmq/perf/PrintlnStatsTest.java
+++ b/src/test/java/com/rabbitmq/perf/PrintlnStatsTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020 VMware, Inc. or its affiliates.  All rights reserved.
+// Copyright (c) 2018-2022 VMware, Inc. or its affiliates.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
@@ -16,6 +16,7 @@
 package com.rabbitmq.perf;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -145,7 +146,7 @@ public class PrintlnStatsTest {
 
     void execute(Configurator configurator) {
         PrintlnStats stats = stats(configurator);
-        stats.report(System.currentTimeMillis());
+        stats.report(System.nanoTime());
         this.output = consoleOut.toString();
     }
 
@@ -170,7 +171,7 @@ public class PrintlnStatsTest {
 
     PrintlnStats stats(Configurator configurator) {
         return new PrintlnStats(
-                "test-id", 1000L,
+                "test-id", Duration.ofMillis(1000),
                 configurator.sendStatsEnabled, configurator.recvStatsEnabled,
                 configurator.returnStatsEnabled, configurator.confirmStatsEnabled,
                 false, configurator.useMillis,

--- a/src/test/java/com/rabbitmq/perf/TopologyTest.java
+++ b/src/test/java/com/rabbitmq/perf/TopologyTest.java
@@ -20,6 +20,7 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.impl.AMQImpl;
+import java.time.Duration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -108,7 +109,7 @@ public class TopologyTest {
 
         params = new MulticastParams();
 
-        when(stats.interval()).thenReturn(-1L);
+        when(stats.interval()).thenReturn(Duration.ofMillis(-1));
     }
 
     @AfterEach

--- a/src/test/java/com/rabbitmq/perf/it/MiscellaneousIT.java
+++ b/src/test/java/com/rabbitmq/perf/it/MiscellaneousIT.java
@@ -31,13 +31,14 @@ import com.rabbitmq.perf.Stats;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,12 +59,12 @@ public class MiscellaneousIT {
 
   AtomicBoolean testIsDone;
   CountDownLatch testLatch;
-  AtomicInteger msgConsumed;
+  AtomicLong msgConsumed;
 
-  Stats stats = new Stats(1000, false, new CompositeMeterRegistry(), "") {
+  Stats stats = new Stats(Duration.ofMillis(1000), false, new CompositeMeterRegistry(), "") {
     @Override
     protected void report(long now) {
-      msgConsumed.set(recvCountTotal);
+      msgConsumed.set(recvCountTotal.get());
     }
   };
 
@@ -74,7 +75,7 @@ public class MiscellaneousIT {
     cf = new ConnectionFactory();
     testIsDone = new AtomicBoolean(false);
     testLatch = new CountDownLatch(1);
-    msgConsumed = new AtomicInteger(0);
+    msgConsumed = new AtomicLong(0);
   }
 
   @AfterEach
@@ -157,7 +158,7 @@ public class MiscellaneousIT {
     String queue = queuesDuringTest.get(0);
 
     ConnectionFactory connectionFactory = new ConnectionFactory();
-    int messageConsumedBeforeDeletion;
+    long messageConsumedBeforeDeletion;
     try (Connection c = connectionFactory.newConnection()) {
       Channel ch = c.createChannel();
       messageConsumedBeforeDeletion = msgConsumed.get();
@@ -187,7 +188,7 @@ public class MiscellaneousIT {
     waitAtMost(10, () -> msgConsumed.get() >= 3 * rate);
 
     ConnectionFactory connectionFactory = new ConnectionFactory();
-    int messageConsumedBeforeDeletion;
+    long messageConsumedBeforeDeletion;
     try (Connection c = connectionFactory.newConnection()) {
       Channel ch = c.createChannel();
       messageConsumedBeforeDeletion = msgConsumed.get();

--- a/src/test/java/com/rabbitmq/perf/it/StartUpIT.java
+++ b/src/test/java/com/rabbitmq/perf/it/StartUpIT.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020 VMware, Inc. or its affiliates.  All rights reserved.
+// Copyright (c) 2019-2022 VMware, Inc. or its affiliates.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
@@ -20,6 +20,8 @@ import com.rabbitmq.perf.MulticastParams;
 import com.rabbitmq.perf.MulticastSet;
 import com.rabbitmq.perf.Stats;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,14 +63,14 @@ public class StartUpIT {
     AtomicBoolean testHasFailed;
     CountDownLatch testLatch;
 
-    AtomicInteger msgPublished, msgConsumed;
+    AtomicLong msgPublished, msgConsumed;
 
-    Stats stats = new Stats(1000, false, new CompositeMeterRegistry(), "") {
+    Stats stats = new Stats(Duration.ofMillis(1000), false, new CompositeMeterRegistry(), "") {
 
         @Override
         protected void report(long now) {
-            msgPublished.set(sendCountTotal);
-            msgConsumed.set(recvCountTotal);
+            msgPublished.set(sendCountTotal.get());
+            msgConsumed.set(recvCountTotal.get());
         }
     };
 
@@ -85,8 +87,8 @@ public class StartUpIT {
         testIsDone = new AtomicBoolean(false);
         testHasFailed = new AtomicBoolean(false);
         testLatch = new CountDownLatch(1);
-        msgConsumed = new AtomicInteger(0);
-        msgPublished = new AtomicInteger(0);
+        msgConsumed = new AtomicLong(0);
+        msgPublished = new AtomicLong(0);
     }
 
     @AfterEach


### PR DESCRIPTION
All the counters are converted to AtomicLong instead of regular, non-volatile properties updated and read in synchronized blocks. This avoids a lot of locking.

The Stats class has also been refactored to use nano time instead of the current time, which is more appropriate and more accurate to measure intervals.