### PR TITLE
Initialize globals metrics once producers/consumer are started

### DIFF
--- a/src/main/java/com/rabbitmq/perf/AgentBase.java
+++ b/src/main/java/com/rabbitmq/perf/AgentBase.java
@@ -17,6 +17,7 @@ package com.rabbitmq.perf;
 
 import com.rabbitmq.client.ShutdownSignalException;
 import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +31,18 @@ public abstract class AgentBase {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AgentBase.class);
 
+    private static final AtomicInteger AGENT_ID_SEQUENCE = new AtomicInteger(0);
+
     private volatile TopologyRecording topologyRecording;
+
+    private final int agentId;
+
+    final StartListener startListener;
+
+    protected AgentBase(StartListener startListener) {
+        this.startListener = startListener == null ? StartListener.NO_OP : startListener;
+        this.agentId = AGENT_ID_SEQUENCE.getAndIncrement();
+    }
 
     public void setTopologyRecording(TopologyRecording topologyRecording) {
         this.topologyRecording = topologyRecording;
@@ -81,6 +93,10 @@ public abstract class AgentBase {
                 throw e;
             }
         }
+    }
+
+    protected void started() {
+        this.startListener.started(this.agentId);
     }
 
     public abstract void recover(TopologyRecording topologyRecording);

--- a/src/main/java/com/rabbitmq/perf/Consumer.java
+++ b/src/main/java/com/rabbitmq/perf/Consumer.java
@@ -99,6 +99,7 @@ public class Consumer extends AgentBase implements Runnable {
     private final boolean rateLimitation;
 
     public Consumer(ConsumerParameters parameters) {
+        super(parameters.getStartListener());
         this.channel           = parameters.getChannel();
         this.id                = parameters.getId();
         this.txSize            = parameters.getTxSize();
@@ -186,6 +187,7 @@ public class Consumer extends AgentBase implements Runnable {
             List<String> queues = this.queueNames.get();
             Channel ch = this.channel;
             Connection connection = this.channel.getConnection();
+            started();
             while (!completed.get() && !Thread.interrupted()) {
                 // queue name can change between recoveries, we refresh only if necessary
                 if (queueNamesVersion != this.queueNamesVersion.get()) {
@@ -233,6 +235,7 @@ public class Consumer extends AgentBase implements Runnable {
     }
 
     private void registerAsynchronousConsumer() {
+        started();
         try {
             q = new ConsumerImpl(channel);
             for (String qName : queueNames.get()) {

--- a/src/main/java/com/rabbitmq/perf/ConsumerParameters.java
+++ b/src/main/java/com/rabbitmq/perf/ConsumerParameters.java
@@ -55,6 +55,8 @@ public class ConsumerParameters {
 
     private ScheduledExecutorService topologyRecoveryScheduledExecutorService;
 
+    private StartListener startListener = StartListener.NO_OP;
+
     public Channel getChannel() {
         return channel;
     }
@@ -243,5 +245,14 @@ public class ConsumerParameters {
 
     public ScheduledExecutorService getTopologyRecoveryScheduledExecutorService() {
         return topologyRecoveryScheduledExecutorService;
+    }
+
+    public StartListener getStartListener() {
+        return startListener;
+    }
+
+    public ConsumerParameters setStartListener(StartListener startListener) {
+        this.startListener = startListener;
+        return this;
     }
 }

--- a/src/main/java/com/rabbitmq/perf/MulticastParams.java
+++ b/src/main/java/com/rabbitmq/perf/MulticastParams.java
@@ -130,6 +130,8 @@ public class MulticastParams {
 
     private boolean cluster = false;
 
+    private StartListener startListener;
+
     public void setExchangeType(String exchangeType) {
         this.exchangeType = exchangeType;
     }
@@ -477,6 +479,10 @@ public class MulticastParams {
         this.queuesInSequence = queuesInSequence;
     }
 
+    public void setStartListener(StartListener startListener) {
+        this.startListener = startListener;
+    }
+
     public Producer createProducer(Connection connection, Stats stats, MulticastSet.CompletionHandler completionHandler,
                                    ValueIndicator<Float> rateIndicator, ValueIndicator<Integer> messageSizeIndicator) throws IOException {
         Channel channel = connection.createChannel(); //NOSONAR
@@ -515,6 +521,7 @@ public class MulticastParams {
             .setRandomStartDelayInSeconds(this.producerRandomStartDelayInSeconds)
             .setRecoveryProcess(recoveryProcess)
             .setRateIndicator(rateIndicator)
+            .setStartListener(this.startListener)
         );
         channel.addReturnListener(producer);
         channel.addConfirmListener(producer);
@@ -568,6 +575,7 @@ public class MulticastParams {
                 .setConsumerArguments(this.consumerArguments)
                 .setExitWhen(this.exitWhen)
                 .setTopologyRecoveryScheduledExecutorService(topologyRecordingScheduledExecutorService)
+                .setStartListener(this.startListener)
         );
         this.topologyHandler.next();
         return consumer;

--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -430,6 +430,18 @@ public class PerfTest {
             };
             shutdownService.wrap(() -> statsSummary.run());
 
+            int agentCount = p.getProducerThreadCount() + p.getConsumerThreadCount();
+            p.setStartListener(new StartListener() {
+                Set<Integer> starts = ConcurrentHashMap.newKeySet(agentCount);
+                @Override
+                public void started(int id) {
+                    if (starts.add(id) && starts.size() == agentCount) {
+                        System.out.println("ALL STARTED " + starts.size());
+                        stats.resetGlobals();
+                    }
+                }
+            });
+
             MulticastSet set = new MulticastSet(stats, factory, p, testID, uris, completionHandler, shutdownService);
             set.run(true);
 

--- a/src/main/java/com/rabbitmq/perf/PrintlnStats.java
+++ b/src/main/java/com/rabbitmq/perf/PrintlnStats.java
@@ -122,7 +122,6 @@ class PrintlnStats extends Stats {
         long elapsedTime = Duration.ofNanos(elapsedInterval.get()).toMillis();
 
         if (sendStatsEnabled) {
-            System.out.println(sendCountInterval.get() + " " + elapsedTime);
             ratePublished = rate(sendCountInterval.get(), elapsedTime);
             published(ratePublished);
         }
@@ -263,25 +262,27 @@ class PrintlnStats extends Stats {
     public void printFinal() {
         if (printFinalOnGoingOrDone.compareAndSet(false, true)) {
             long now = System.nanoTime();
+            long st = this.startTimeForGlobals.get();
+            long elapsed = Duration.ofNanos(now - st).toMillis();
+            System.out.println(sendCountTotal.get() + " " + elapsed);
             String lineSeparator = System.getProperty("line.separator");
             StringBuilder summary = new StringBuilder("id: " + testID + ", sending rate avg: " +
-                    formatRate(sendCountTotal.get() * NANO_TO_SECOND / (now - startTime)) +
+                    formatRate(sendCountTotal.get() * MS_TO_SECOND / elapsed) +
                     " " + MESSAGE_RATE_LABEL);
             summary.append(lineSeparator);
 
-            long elapsed = now - startTime;
             if (elapsed > 0) {
                 summary.append("id: " + testID + ", receiving rate avg: " +
-                        formatRate(recvCountTotal.get() * NANO_TO_SECOND / elapsed) +
+                        formatRate(recvCountTotal.get() * MS_TO_SECOND / elapsed) +
                         " " + MESSAGE_RATE_LABEL).append(lineSeparator);
                 if (shouldDisplayConsumerLatency()) {
                     summary.append(format("id: %s, consumer latency %s %s",
-                        testID, LATENCY_HEADER, latencyReport(this.globalLatency)
+                        testID, LATENCY_HEADER, latencyReport(this.globalLatency.get())
                     )).append(lineSeparator);
                 }
                 if (shouldDisplayConfirmLatency()) {
                     summary.append(format("id: %s, confirm latency %s %s",
-                        testID, LATENCY_HEADER, latencyReport(this.globalConfirmLatency)
+                        testID, LATENCY_HEADER, latencyReport(this.globalConfirmLatency.get())
                     )).append(lineSeparator);
                 }
                 System.out.print(summary);

--- a/src/main/java/com/rabbitmq/perf/Producer.java
+++ b/src/main/java/com/rabbitmq/perf/Producer.java
@@ -105,6 +105,7 @@ public class Producer extends AgentBase implements Runnable, ReturnListener,
     private final Runnable rateLimiterCallback;
 
     public Producer(ProducerParameters parameters) {
+        super(parameters.getStartListener());
         this.channel           = parameters.getChannel();
         this.exchangeName      = parameters.getExchangeName();
         this.id                = parameters.getId();
@@ -372,6 +373,7 @@ public class Producer extends AgentBase implements Runnable, ReturnListener,
         state.setLastStatsTime(startTime);
         state.setMsgCount(0);
         final boolean variableRate = this.rateIndicator.isVariable();
+        started();
         try {
             while (keepGoing(state)) {
                 rateLimiterCallback.run();
@@ -481,6 +483,7 @@ public class Producer extends AgentBase implements Runnable, ReturnListener,
             if (initialized.compareAndSet(false, true)) {
                 state.setLastStatsTime(System.nanoTime());
                 state.setMsgCount(0);
+                started();
             }
             try {
                 maybeHandlePublish(state);

--- a/src/main/java/com/rabbitmq/perf/ProducerParameters.java
+++ b/src/main/java/com/rabbitmq/perf/ProducerParameters.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020 VMware, Inc. or its affiliates.  All rights reserved.
+// Copyright (c) 2018-2022 VMware, Inc. or its affiliates.  All rights reserved.
 //
 // This software, the RabbitMQ Java client library, is triple-licensed under the
 // Mozilla Public License 2.0 ("MPL"), the GNU General Public License version 2
@@ -43,6 +43,7 @@ public class ProducerParameters {
     private int randomStartDelayInSeconds;
     private Recovery.RecoveryProcess recoveryProcess;
     private ValueIndicator<Float> rateIndicator;
+    private StartListener startListener = StartListener.NO_OP;
 
     public Channel getChannel() {
         return channel;
@@ -203,6 +204,15 @@ public class ProducerParameters {
 
     public ProducerParameters setRateIndicator(ValueIndicator<Float> rateIndicator) {
         this.rateIndicator = rateIndicator;
+        return this;
+    }
+
+    public StartListener getStartListener() {
+        return startListener;
+    }
+
+    public ProducerParameters setStartListener(StartListener startListener) {
+        this.startListener = startListener;
         return this;
     }
 }

--- a/src/main/java/com/rabbitmq/perf/StartListener.java
+++ b/src/main/java/com/rabbitmq/perf/StartListener.java
@@ -1,0 +1,9 @@
+package com.rabbitmq.perf;
+
+public interface StartListener {
+
+  StartListener NO_OP = id -> { };
+
+  void started(int id);
+
+}


### PR DESCRIPTION
Global metrics (shown in the summary at the end of a run) can be skewed if producers/consumers are started with a delay. Producers and consumers now notify a listener that resets the global metrics once everyone is started.

References #401, #406