### PR TITLE
Add support for boolean queue/consumer arguments

### DIFF
--- a/src/main/java/com/rabbitmq/perf/PerfTest.java
+++ b/src/main/java/com/rabbitmq/perf/PerfTest.java
@@ -858,6 +858,10 @@ public class PerfTest {
             String [] keyValue = entry.split("=");
             if (keyValue.length == 1) {
                 return new Object[] {keyValue[0], ""};
+            } else if ("true".equals(keyValue[1])) {
+                return new Object[] {keyValue[0], true};
+            } else if ("false".equals(keyValue[1])) {
+                return new Object[] {keyValue[0], false};
             } else {
                 try {
                     return new Object[] {keyValue[0], Long.parseLong(keyValue[1])};

--- a/src/test/java/com/rabbitmq/perf/PerfTestTest.java
+++ b/src/test/java/com/rabbitmq/perf/PerfTestTest.java
@@ -123,6 +123,14 @@ public class PerfTestTest {
             .hasSize(2)
             .containsEntry("x-queue-type", "quorum")
             .containsEntry("max-length-bytes", 10L);
+       assertThat(convertKeyValuePairs("x-cancel-on-ha-failover=true,x-priority=10"))
+            .hasSize(2)
+            .containsEntry("x-cancel-on-ha-failover", true)
+            .containsEntry("x-priority", 10L);
+       assertThat(convertKeyValuePairs("x-cancel-on-ha-failover=false,x-priority=10"))
+            .hasSize(2)
+            .containsEntry("x-cancel-on-ha-failover", false)
+            .containsEntry("x-priority", 10L);
     }
 
     @Test


### PR DESCRIPTION
E.g. `x-cancel-on-ha-failover` arg for consumers of classic mirrored queues.