### PR TITLE
Use durable exchanges

### DIFF
--- a/src/main/java/com/rabbitmq/perf/Utils.java
+++ b/src/main/java/com/rabbitmq/perf/Utils.java
@@ -189,7 +189,7 @@ abstract class Utils {
     if ("".equals(exchange) || exchange.startsWith("amq.")) {
       LOGGER.info("Skipping creation of exchange {}", exchange);
     }
-    channel.exchangeDeclare(exchange, type);
+    channel.exchangeDeclare(exchange, type, true);
   }
 
   interface Checker {


### PR DESCRIPTION
Since we are removing ephemeral exchanges in RabbitMQ 4.0, I don't think there is a point in introducing a flag to control exchange durability at this point - they are just all durable from now on.