### PR TITLE
Do not crash on timestamp extraction

### DIFF
--- a/src/main/java/com/rabbitmq/perf/Consumer.java
+++ b/src/main/java/com/rabbitmq/perf/Consumer.java
@@ -147,7 +147,7 @@ public class Consumer extends AgentBase implements Runnable {
                     d.readInt(); // read sequence number
                     return d.readLong();
                 } catch (IOException e) {
-                    throw new RuntimeException("Error while extracting timestamp from body");
+                    return Long.MAX_VALUE;
                 }
 
             };

--- a/src/test/java/com/rabbitmq/perf/PerfTestTest.java
+++ b/src/test/java/com/rabbitmq/perf/PerfTestTest.java
@@ -15,7 +15,6 @@
 
 package com.rabbitmq.perf;
 
-import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;


### PR DESCRIPTION
E.g. when reading from a stream which contains
messages from stream-perf-test.