### PR TITLE
Bump wrangler cli in CI

### DIFF
--- a/ci/worker/package.json
+++ b/ci/worker/package.json
@@ -5,11 +5,11 @@
     "@cloudflare/kv-asset-handler": "^0.2.0",
     "@cloudflare/workers-types": "^4.20221111.1",
     "typescript": "^4.9.4",
-    "wrangler": "2.6.1"
+    "wrangler": "^3.1.1"
   },
   "private": true,
   "scripts": {
     "start": "wrangler dev",
-    "deploy": "wrangler publish"
+    "deploy": "wrangler deploy"
   }
 }


### PR DESCRIPTION
Bumping wrangler to, at least, 3.1.1. The caret ^ in the version will
make sure we keep in the latest version of 3.x major version. There are
no special considerations to upgrade to v3, according to:

https://developers.cloudflare.com/workers/wrangler/migration/update-v2-to-v3/

There is one deprecation that affects us. Wrangler publish is deprecated
in favour of wrangler deploy. Both take same arguments:

https://developers.cloudflare.com/workers/wrangler/deprecations/#publish

