### PR TITLE
Dispatch messages only when channel is open

### DIFF
--- a/src/main/java/com/rabbitmq/perf/Consumer.java
+++ b/src/main/java/com/rabbitmq/perf/Consumer.java
@@ -214,7 +214,7 @@ public class Consumer extends AgentBase implements Runnable {
                 try {
                   GetResponse response = ch.basicGet(queue, autoAck);
                   if (response != null) {
-                    delegate.handleMessage(
+                    delegate.maybeHandleMessage(
                         response.getEnvelope(), response.getProps(), response.getBody(), ch);
                   }
                 } catch (IOException e) {
@@ -280,7 +280,13 @@ public class Consumer extends AgentBase implements Runnable {
     public void handleDelivery(
         String consumerTag, Envelope envelope, BasicProperties properties, byte[] body)
         throws IOException {
-      this.handleMessage(envelope, properties, body, channel);
+      this.maybeHandleMessage(envelope, properties, body, channel);
+    }
+
+    private void maybeHandleMessage(Envelope envelope, BasicProperties properties, byte[] body, Channel ch) throws IOException {
+      if (ch.isOpen()) {
+        handleMessage(envelope, properties, body, ch);
+      }
     }
 
     void handleMessage(Envelope envelope, BasicProperties properties, byte[] body, Channel ch)


### PR DESCRIPTION
This makes PerfTest more reactive with large prefetch and long processing times: client TCP buffer gets full, the broker cannot write to the client socket, it closes the connection (after a 30-second timeout by default), the client tries to close the connection channels, but it uses the consumer dispatcher to do so, and it is busy processing the slow messages, so the channels are never properly shut down. Recovery cannot occur then.

By dispatching messages only when the channel is open, the consumer dispatcher backlog gets cleared right away, channels get closed normally and recovery can kick in.